### PR TITLE
Corrects intended behavior of restart button

### DIFF
--- a/custom_components/unfoldedcircle/button.py
+++ b/custom_components/unfoldedcircle/button.py
@@ -70,4 +70,4 @@ class Button(ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self._remote.post_system_command("RESTART")
+        await self._remote.post_system_command("REBOOT")


### PR DESCRIPTION
The restart button was calling 'Restart' which only restarts the applications. The command to reboot the device is reboot.