### PR TITLE
Unified intregration updated

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,8 +47,10 @@
           "!include_dir_merge_named scalar"
         ],
         "[python]": {
-          "editor.defaultFormatter": "charliermarsh.ruff"
-        }
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true
+        },
+        "ruff.organizeImports": true
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,36 +5,56 @@
   "postCreateCommand": ".devcontainer/setup",
   "postAttachCommand": ".devcontainer/setup",
   "forwardPorts": [8123],
+  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "containerEnv": {
+    "PYTHONASYNCIODEBUG": "1"
+  },
   "customizations": {
     "vscode": {
       "extensions": [
-        "ms-python.python",
-        "ms-python.black-formatter",
-        "ms-python.isort",
+        "charliermarsh.ruff",
         "ms-python.pylint",
         "ms-python.vscode-pylance",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-yaml",
         "esbenp.prettier-vscode",
-        "github.vscode-pull-request-github",
-        "ryanluker.vscode-coverage-gutters"
+        "GitHub.vscode-pull-request-github",
+        "GitHub.copilot"
       ],
       "settings": {
-        "files.eol": "\n",
-        "editor.tabSize": 4,
-        "python.pythonPath": "/usr/bin/python3",
-        "python.analysis.autoSearchPaths": false,
-        "python.formatting.provider": "black",
+        "python.experiments.optOutFrom": ["pythonTestAdapter"],
+        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.terminal.activateEnvInCurrentTerminal": true,
+        "python.testing.pytestArgs": ["--no-cov"],
+        "pylint.importStrategy": "fromEnvironment",
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
-        "editor.codeActionsOnSave": {
-          "source.organizeImports": true
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
         },
-        "files.trimTrailingWhitespace": true
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "yaml.customTags": [
+          "!input scalar",
+          "!secret scalar",
+          "!include_dir_named scalar",
+          "!include_dir_list scalar",
+          "!include_dir_merge_list scalar",
+          "!include_dir_merge_named scalar"
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
       }
     }
   },
   "remoteUser": "vscode",
   "features": {
-    "rust": "latest"
+    "rust": "latest",
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,16 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Home Assistant",
-        "type": "python",
-        "request": "launch",
-        "module": "homeassistant",
-        "justMyCode": false,
-        "args": ["--debug", "-c", "config"]
-      }
-    ]
-  }
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Home Assistant",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "config"]
+    }
+  ]
+}

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["--no-cov"],
+  "python.testing.pytestEnabled": false,
+  "pylint.importStrategy": "fromEnvironment"
+}

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -14,18 +14,22 @@ sequenceDiagram
     HA UC Component->>Home Assistant:Create a HA token for websocket
     HA UC Component->>Remote:Sends the HA token to the remote for HA driver
     Remote->>Remote HA driver:Sends the HA token to the HA driver
-    Remote->HA UC Component:HA token registered
-    HA UC Component->>HA UC Component:A delay is necessary so that the driver is notified and connects to HA
+    Remote->>HA UC Component:HA token registered
+    HA UC Component->>Remote: Search for HA integration and reload entities intg/instances/hass.main/entities?reload=true
+    activate HA UC Component
+    HA UC Component->>HA UC Component:Delay is necessary, polling until HA driver registers
     Remote HA driver->>Remote HA driver:Store the HA token and connect to HA (close existing connection if any)
     Remote HA driver->>Home Assistant:Connect and auth to HA websocket
     Remote HA driver->>Home Assistant:Try to register UC (entities & configuration) events
     Home Assistant->>HA UC Component:HA notifies the component of new events subscriptions
-    HA UC Component->>HA UC Component:After a delay, event subscribed with current subscribed entities 
+    deactivate HA UC Component
+    HA UC Component->>HA UC Component:After a delay, HA is notified with the current subscribed entities 
     HA UC Component->>User:Show the entities to add or remove according to subscribed entities
     User->>HA UC Component:Select the entities to subscribe
-    HA UC Component->>Remote HA driver:Notify the new list of subscribed entities
-    HA UC Component->>HA UC Component:Wait 2 seconds
+    HA UC Component->>Remote HA driver:Notify the new list of available entities
+    HA UC Component->>Remote: Force reload entities again intg/instances/hass.main/entities?reload=true
+    HA UC Component->>HA UC Component:Wait 2 seconds that remote receives the new list from the driver
     Remote HA driver->>Remote:Store the new list (? and sends the new entities to the remote)
     HA UC Component->>Remote:Register all available entities (no list to submit)
-    Remote->>Remote HA driver:What is going on at this step ?
+    HA UC Component->>User: Setup flow is finished and the remote is registered
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Discord](https://badgen.net/discord/online-members/zGVYf58)](https://discord.gg/zGVYf58)
 ![GitHub Release](https://img.shields.io/github/v/release/jackjpowell/hass-unfoldedcircle)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/jackjpowell/hass-unfoldedcircle/total)
-[![Buy Me A Coffee/Beer](https://img.shields.io/badge/Buy_Me_A_☕/🍺-F16061?logo=ko-fi&logoColor=white&labelColor=grey)](https://ko-fi.com/jackjpowell)
 <a href="#"><img src="https://img.shields.io/maintenance/yes/2024.svg"></a>
+<!--[![Buy Me A Coffee/Beer](https://img.shields.io/badge/Buy_Me_A_☕/🍺-F16061?logo=ko-fi&logoColor=white&labelColor=grey)](https://ko-fi.com/jackjpowell)-->
+
 
 ## hass-unfoldedcircle
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![GitHub Release](https://img.shields.io/github/v/release/jackjpowell/hass-unfoldedcircle)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/jackjpowell/hass-unfoldedcircle/total)
 <a href="#"><img src="https://img.shields.io/maintenance/yes/2024.svg"></a>
-<!--[![Buy Me A Coffee/Beer](https://img.shields.io/badge/Buy_Me_A_☕/🍺-F16061?logo=ko-fi&logoColor=white&labelColor=grey)](https://ko-fi.com/jackjpowell)-->
 
+<!--[![Buy Me A Coffee/Beer](https://img.shields.io/badge/Buy_Me_A_☕/🍺-F16061?logo=ko-fi&logoColor=white&labelColor=grey)](https://ko-fi.com/jackjpowell)-->
 
 ## hass-unfoldedcircle
 
@@ -22,10 +22,10 @@ There are two main ways to install this custom component within your Home Assist
 
 1. Using HACS (see https://hacs.xyz/ for installation instructions if you do not already have it installed):
 
-    [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=JackJPowell&repository=hass-unfoldedcircle&category=Integration)
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=JackJPowell&repository=hass-unfoldedcircle&category=Integration)
 
    Or
-   
+
    1. From within Home Assistant, click on the link to **HACS**
    2. Click on **Integrations**
    3. Click on the vertical ellipsis in the top right and select **Custom repositories**
@@ -33,10 +33,10 @@ There are two main ways to install this custom component within your Home Assist
    5. Click the **ADD** button
    6. Close the _Custom repositories_ window
    7. You should now be able to see the _Unfolde Circle_ card on the HACS Integrations page. Click on **INSTALL** and proceed with the installation instructions.
- 
+
    Restart your Home Assistant instance and then proceed to the _Configuration_ section below.
 
-3. Manual Installation:
+2. Manual Installation:
    1. Download or clone this repository
    2. Copy the contents of the folder **custom_components/unfoldedcircle** into the same file structure on your Home Assistant instance
    3. Restart your Home Assistant instance and then proceed to the _Configuration_ section below.
@@ -98,11 +98,29 @@ After the device is configured, the integration will expose 22 entities plus the
   - A media player entity is created providing controls and information about currently playing media. If multiple media player entities are active, the integration attempts to select the most appropriate based on activity and recency.
     - You can override this behavior by selecting a different media source from the sound mode menu in the Media Player control
     - Options exist to create a media player per activity group or per activity.
-  - **Update** The media player controls are now mapped to the selected activity's button mapping on the remote. The default is still the active media player, but if you have defined custom volume, next, previous, or power button commands, those will be executed when interacting with the control within home assistant. 
+  - **Update** The media player controls are now mapped to the selected activity's button mapping on the remote. The default is still the active media player, but if you have defined custom volume, next, previous, or power button commands, those will be executed when interacting with the control within home assistant.
 - Number
+
   - Configuration Controls: All numerical settings are now controllable via the integration.
 
   \*\* Disabled by default to avoid polling the remote every thirty seconds to read data. If one of these sensors is enabled, polling only for that specific data will also be enabled.
+
+## Dock Support
+
+Dock support has now been added. If you have an existing remote configured, you will be prompted with a repair for each dock associated with your remote. You can also add docks via a configuration flow when adding a remote. Each Dock exposes 4 entities:
+
+- Buttons
+
+  - Reboot Dock: Allows you to remotely reboot the dock
+  - Identity: Causes the LED to flash to help you identify which dock is which
+
+- Number
+  - LED Brightness: Allows you to set the LED brightness level
+  - Ethernet Brightness: Allows you to set the Ethernet LED brightness level
+
+During a config flow, if you are unsure of your password, you can skip adding that dock for the moment by submitting the form without a password supplied. This will cause a repair to be created so you can set it at your leasure.
+
+If you are unsure of the password you set, you can change it via the web configurator. Click on the Integrations and Dock menu and then select the dock you need to change the password for. Once changed, come back to the repair and let home assistant know what you set it to.
 
 ## IR Remote Commands
 
@@ -120,8 +138,10 @@ target:
 
 > [!TIP] > **device:** will match the case-sensitive name of your remote defined in the web configurator on the remote page. **command** will match the case-senstitive name of the pre-defined (custom or codeset) command defined for that remote. **num_repeats** is optional.
 
-## Additional Services
-There is now a service to update defined activities. This will be initially released with the option to enable/disable the 'prevent sleep' option within the selected activity. 
+## Additional Actions
+
+There is now an action to update defined activities. This will be initially released with the option to enable/disable the 'prevent sleep' option within the selected activity.
+
 ```
 service: unfoldedcircle.update_activity
 target:
@@ -130,7 +150,42 @@ data:
   prevent_sleep: true
 ```
 
-**Update Activity**
+## IR Learning
+
+**_BETA: This will be available in the wide release soon_**
+
+You can now rapidly learn IR commands through your dock. To get started, go to your developer tools and then to the services tab and recreate the example below with your data. Start by providing a remote entity of the dock you want to learn through. Then add information about the remote to be created in the Unfolded Circle Software (name, icon, and description). Follow that with your IR dataset. Give it a name and a list of commands you would like to learn.
+
+```
+service: unfoldedcircle.learn_ir_command
+target:
+  entity_id: remote.remote_dock_remote
+data:
+  remote:
+    name: Sony TV
+    icon: uc:tv
+    description: My Sony TV Remote
+  ir_dataset:
+    name: Sony A95L
+    command:
+      - direction_up
+      - direction_right
+      - direction_down
+      - direction_left
+      - menu
+      - back
+      - home
+```
+
+Finally, run this by clicking call service. This will start the dock listening for your commands. If you check your home assistant notifications, you'll get feedback on which step you are on. Continue by clicking the button on your remote that is shown in the notification while pointing at your dock.
+
+![Screenshot 2024-08-02 at 6 44 12 PM](https://github.com/user-attachments/assets/7b312f16-4c76-4d67-81bc-901f3e07e095)
+
+If you run the above you will end up with the following in your Unfolded Circle Remote's web configurator that you can then assign to virtual or physical buttons:
+
+![Screenshot 2024-08-02 at 6 27 48 PM](https://github.com/user-attachments/assets/c1b37321-3a61-4e22-b0c1-aeef94379e77)
+
+![Screenshot 2024-08-02 at 6 34 13 PM](https://github.com/user-attachments/assets/2722b8ff-9d9d-4e22-a809-f75091372b5d)
 
 ## Options
 

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -32,7 +32,6 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Unfolded Circle Remote from a config entry."""
-
     try:
         remote_api = Remote(entry.data["host"], entry.data["pin"], entry.data["apiKey"])
         await remote_api.can_connect()
@@ -51,7 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Extract activities and activity groups
     await coordinator.api.init()
-
     # Retrieve info from Remote
     # Get Basic Device Information
     await coordinator.async_config_entry_first_refresh()
@@ -70,7 +68,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: UnfoldedCircleRemoteCoordinator = hass.data[DOMAIN][
             entry.entry_id
         ][UNFOLDED_CIRCLE_COORDINATOR]
-        await coordinator.close_websocket()
+        # Close websocket for remote coordinators or cancel subscribed events for global coordinator
+        await coordinator.close()
+        # TODO : unsubscribe events ?
     except Exception as ex:
         _LOGGER.error("Unfolded Circle Remote async_unload_entry error: %s", ex)
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -10,10 +10,10 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.network import get_url
-from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 from .const import DOMAIN, UNFOLDED_CIRCLE_API, UNFOLDED_CIRCLE_COORDINATOR
 from .coordinator import UnfoldedCircleRemoteCoordinator
+from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 PLATFORMS: list[Platform] = [
     Platform.SWITCH,

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -1,19 +1,28 @@
 """The Unfolded Circle Remote integration."""
 
 from __future__ import annotations
-
+from typing import Any
 import logging
 
 from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er, issue_registry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.network import get_url
 
-from .const import DOMAIN, UNFOLDED_CIRCLE_API, UNFOLDED_CIRCLE_COORDINATOR
-from .coordinator import UnfoldedCircleRemoteCoordinator
-from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
+from .const import (
+    DOMAIN,
+    UNFOLDED_CIRCLE_API,
+    UNFOLDED_CIRCLE_COORDINATOR,
+    UNFOLDED_CIRCLE_DOCK_COORDINATORS,
+)
+from .coordinator import (
+    UnfoldedCircleRemoteCoordinator,
+    UnfoldedCircleDockCoordinator,
+)
 
 PLATFORMS: list[Platform] = [
     Platform.SWITCH,
@@ -32,6 +41,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Unfolded Circle Remote from a config entry."""
+
     try:
         remote_api = Remote(entry.data["host"], entry.data["pin"], entry.data["apiKey"])
         await remote_api.can_connect()
@@ -39,26 +49,107 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     except AuthenticationError as err:
         raise ConfigEntryAuthFailed(err) from err
+    except ConnectionError as err:
+        raise ConfigEntryNotReady(err) from err
     except Exception as ex:
         raise ConfigEntryNotReady(ex) from ex
 
+    dock_coordinators: list[UnfoldedCircleDockCoordinator] = []
     coordinator = UnfoldedCircleRemoteCoordinator(hass, remote_api)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        UNFOLDED_CIRCLE_COORDINATOR: coordinator,
-        UNFOLDED_CIRCLE_API: remote_api,
-    }
 
     # Extract activities and activity groups
     await coordinator.api.init()
+
+    @callback
+    def async_migrate_entity_entry(
+        entry: er.RegistryEntry,
+    ) -> dict[str, Any] | None:
+        """Migrate Unfolded Circle entity entries.
+
+        - Migrates old unique ID's to the new unique ID's
+        """
+        if (
+            entry.domain != Platform.UPDATE
+            and entry.domain != Platform.SWITCH
+            and "ucr" not in entry.unique_id.lower()
+            and "ucd" not in entry.unique_id.lower()
+        ):
+            new = f"{coordinator.api.model_number}_{entry.unique_id}"
+            return {"new_unique_id": entry.unique_id.replace(entry.unique_id, new)}
+
+        if (
+            entry.domain == Platform.SWITCH
+            and "ucr" not in entry.unique_id.lower()
+            and "ucd" not in entry.unique_id.lower()
+            and "uc.main" not in entry.unique_id
+        ):
+            new = f"{coordinator.api.model_number}_{entry.unique_id}"
+            return {"new_unique_id": entry.unique_id.replace(entry.unique_id, new)}
+
+        if (
+            entry.domain == Platform.UPDATE
+            and "ucr" not in entry.unique_id.lower()
+            and "ucd" not in entry.unique_id.lower()
+        ):
+            new = f"{coordinator.api.model_number}_{coordinator.api.serial_number}_update_status"
+            return {"new_unique_id": entry.unique_id.replace(entry.unique_id, new)}
+
+        # No migration needed
+        return None
+
+    # Migrate unique ID -- Make the ID actually Unique.
+    # Migrate Device Name -- Make the device name match the psn username
+    # We can remove this logic after a reasonable period of time has passed.
+    if entry.version == 1:
+        await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
+        _migrate_device_identifiers(hass, entry.entry_id, coordinator)
+        _update_config_entry(hass, entry, coordinator)
+        hass.config_entries.async_update_entry(entry, version=2)
+
     # Retrieve info from Remote
     # Get Basic Device Information
+    for dock in remote_api._docks:
+        for config_entry in entry.data["docks"]:
+            if config_entry.get("id") == dock.id:
+                dock._password = config_entry.get("password")
+                break
+        if dock.has_password:
+            dock_coordinator = UnfoldedCircleDockCoordinator(hass, dock)
+            dock_coordinators.append(dock_coordinator)
+            await dock_coordinator.api.update()
+            await dock_coordinator.async_config_entry_first_refresh()
+            await dock_coordinator.init_websocket()
+        else:
+            issue_registry.async_create_issue(
+                hass,
+                DOMAIN,
+                f"dock_password_{dock.id}",
+                breaks_in_ha_version=None,
+                data={
+                    "id": dock.id,
+                    "name": dock.name,
+                    "config_entry_id": entry.entry_id,
+                },
+                is_fixable=True,
+                is_persistent=False,
+                learn_more_url="https://github.com/jackjpowell/hass-unfoldedcircle",
+                severity=issue_registry.IssueSeverity.WARNING,
+                translation_key="dock_password",
+                translation_placeholders={"name": dock.name},
+            )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        UNFOLDED_CIRCLE_COORDINATOR: coordinator,
+        UNFOLDED_CIRCLE_API: remote_api,
+        UNFOLDED_CIRCLE_DOCK_COORDINATORS: dock_coordinators,
+    }
+
     await coordinator.async_config_entry_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await zeroconf.async_get_async_instance(hass)
     await coordinator.init_websocket()
-    # await auth_tests(hass, remote_api)
     return True
 
 
@@ -68,9 +159,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator: UnfoldedCircleRemoteCoordinator = hass.data[DOMAIN][
             entry.entry_id
         ][UNFOLDED_CIRCLE_COORDINATOR]
-        # Close websocket for remote coordinators or cancel subscribed events for global coordinator
-        await coordinator.close()
-        # TODO : unsubscribe events ?
+        await coordinator.close_websocket()
+
+        for dock in coordinator.api._docks:
+            issue_registry.async_delete_issue(hass, DOMAIN, f"dock_password_{dock.id}")
     except Exception as ex:
         _LOGGER.error("Unfolded Circle Remote async_unload_entry error: %s", ex)
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
@@ -87,40 +179,50 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-## Temporary block to help with testing auth endpoints
-## remove before release
-async def auth_tests(hass, remote_api) -> None:
-    ##Lets test some methods
-    instance_url = get_url(hass)
-    systems = await remote_api.get_registered_external_systems()
-    tokens = await remote_api.get_tokens_for_external_system("homeassistant")
-    token_id = await remote_api.set_token_for_external_system(
-        "homeassistant",
-        "test-token-id",
-        "test-token-value",
-        "Home Assistant",
-        "HA Desc",
-        instance_url,
-        "data",
-    )
-    token_id = await remote_api.set_token_for_external_system(
-        "homeassistant",
-        "test-token-id",
-        "test-token-value2",
-        "Home Assistant2",
-        "HA Desc2",
-        instance_url,
-        "data2",
-    )
-    token_id = await remote_api.update_token_for_external_system(
-        "homeassistant",
-        "test-token-id",
-        "test-token-value3",
-        "Home Assistant3",
-        "HA Desc3",
-        instance_url,
-        "data3",
-    )
-    status = await remote_api.delete_token_for_external_system(
-        "homeassistant", "test-token-id"
-    )
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    return True
+
+
+def _update_config_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: UnfoldedCircleRemoteCoordinator,
+) -> bool:
+    """Update config entry with dock information"""
+    if "docks" not in config_entry.data:
+        docks = []
+        for dock in coordinator.api._docks:
+            docks.append({"id": dock.id, "name": dock.name, "password": ""})
+
+        updated_data = {**config_entry.data}
+        updated_data["docks"] = docks
+
+        hass.config_entries.async_update_entry(config_entry, data=updated_data)
+    return True
+
+
+def _migrate_device_identifiers(
+    hass: HomeAssistant, entry_id: str, coordinator
+) -> None:
+    """Migrate old device identifiers."""
+    dev_reg = dr.async_get(hass)
+    devices: list[dr.DeviceEntry] = dr.async_entries_for_config_entry(dev_reg, entry_id)
+    for device in devices:
+        old_identifier = list(next(iter(device.identifiers)))
+        if (
+            "ucr" not in old_identifier[1].lower()
+            and "ucd" not in old_identifier[1].lower()
+        ):
+            new_identifier = {
+                (
+                    DOMAIN,
+                    coordinator.api.model_number,
+                    coordinator.api.serial_number,
+                )
+            }
+            _LOGGER.debug(
+                "migrate identifier '%s' to '%s'",
+                device.identifiers,
+                new_identifier,
+            )
+            dev_reg.async_update_device(device.id, new_identifiers=new_identifier)

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er, issue_registry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.network import get_url
+from pyUnfoldedCircleRemote.remote import Remote, AuthenticationError
 
 from .const import (
     DOMAIN,

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.network import get_url
-from pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
+from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 from .const import DOMAIN, UNFOLDED_CIRCLE_API, UNFOLDED_CIRCLE_COORDINATOR
 from .coordinator import UnfoldedCircleRemoteCoordinator

--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.network import get_url
 from pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 from .const import DOMAIN, UNFOLDED_CIRCLE_API, UNFOLDED_CIRCLE_COORDINATOR
@@ -59,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(update_listener))
     await zeroconf.async_get_async_instance(hass)
     await coordinator.init_websocket()
+    # await auth_tests(hass, remote_api)
     return True
 
 
@@ -83,3 +85,42 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     # await async_unload_entry(hass, entry)
     # await async_setup_entry(hass, entry)
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+## Temporary block to help with testing auth endpoints
+## remove before release
+async def auth_tests(hass, remote_api) -> None:
+    ##Lets test some methods
+    instance_url = get_url(hass)
+    systems = await remote_api.get_registered_external_systems()
+    tokens = await remote_api.get_tokens_for_external_system("homeassistant")
+    token_id = await remote_api.set_token_for_external_system(
+        "homeassistant",
+        "test-token-id",
+        "test-token-value",
+        "Home Assistant",
+        "HA Desc",
+        instance_url,
+        "data",
+    )
+    token_id = await remote_api.set_token_for_external_system(
+        "homeassistant",
+        "test-token-id",
+        "test-token-value2",
+        "Home Assistant2",
+        "HA Desc2",
+        instance_url,
+        "data2",
+    )
+    token_id = await remote_api.update_token_for_external_system(
+        "homeassistant",
+        "test-token-id",
+        "test-token-value3",
+        "Home Assistant3",
+        "HA Desc3",
+        instance_url,
+        "data3",
+    )
+    status = await remote_api.delete_token_for_external_system(
+        "homeassistant", "test-token-id"
+    )

--- a/custom_components/unfoldedcircle/binary_sensor.py
+++ b/custom_components/unfoldedcircle/binary_sensor.py
@@ -19,9 +19,10 @@ async def async_setup_entry(
 ) -> None:
     """Use to setup entity."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][UNFOLDED_CIRCLE_COORDINATOR]
-    async_add_entities(
-        [BatteryBinarySensor(coordinator), PollingBinarySensor(coordinator)]
-    )
+    async_add_entities([
+        BatteryBinarySensor(coordinator),
+        PollingBinarySensor(coordinator),
+    ])
 
 
 class PollingBinarySensor(UnfoldedCircleEntity, BinarySensorEntity):

--- a/custom_components/unfoldedcircle/binary_sensor.py
+++ b/custom_components/unfoldedcircle/binary_sensor.py
@@ -19,10 +19,12 @@ async def async_setup_entry(
 ) -> None:
     """Use to setup entity."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][UNFOLDED_CIRCLE_COORDINATOR]
-    async_add_entities([
-        BatteryBinarySensor(coordinator),
-        PollingBinarySensor(coordinator),
-    ])
+    async_add_entities(
+        [
+            BatteryBinarySensor(coordinator),
+            PollingBinarySensor(coordinator),
+        ]
+    )
 
 
 class PollingBinarySensor(UnfoldedCircleEntity, BinarySensorEntity):
@@ -36,10 +38,11 @@ class PollingBinarySensor(UnfoldedCircleEntity, BinarySensorEntity):
         super().__init__(coordinator)
 
         # As per the sensor, this must be a unique value within this domain.
-        self._attr_unique_id = f"{self.coordinator.api.serial_number}_polling_status"
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_polling_status"
 
         # The name of the entity
-        self._attr_name = f"{self.coordinator.api.name} Polling Status"
+        self._attr_has_entity_name = True
+        self._attr_name = "Polling Status"
         self._attr_native_value = self.coordinator.polling_data
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._extra_state_attributes = {}
@@ -66,7 +69,7 @@ class PollingBinarySensor(UnfoldedCircleEntity, BinarySensorEntity):
             self.coordinator.websocket_task is not None
         )
         self._extra_state_attributes["Websocket events"] = ", ".join(
-            self.coordinator.remote_websocket.events_to_subscribe
+            self.coordinator.websocket.events_to_subscribe
         )
         self.async_write_ha_state()
 
@@ -83,9 +86,9 @@ class BatteryBinarySensor(UnfoldedCircleEntity, BinarySensorEntity):
     def __init__(self, coordinator) -> None:
         """Initialize Binary Sensor."""
         super().__init__(coordinator)
-
-        self._attr_unique_id = f"{self.coordinator.api.serial_number}_charging_status"
-        self._attr_name = f"{self.coordinator.api.name} Charging Status"
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_charging_status"
+        self._attr_name = "Charging Status"
         self._attr_native_value = False
 
     @property

--- a/custom_components/unfoldedcircle/button.py
+++ b/custom_components/unfoldedcircle/button.py
@@ -6,8 +6,12 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
-from .entity import UnfoldedCircleEntity
+from .const import (
+    DOMAIN,
+    UNFOLDED_CIRCLE_COORDINATOR,
+    UNFOLDED_CIRCLE_DOCK_COORDINATORS,
+)
+from .entity import UnfoldedCircleEntity, UnfoldedCircleDockEntity
 
 
 async def async_setup_entry(
@@ -17,21 +21,36 @@ async def async_setup_entry(
 ) -> None:
     """Set up entity in HA."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][UNFOLDED_CIRCLE_COORDINATOR]
-    async_add_entities([RebootButton(coordinator), UpdateCheckButton(coordinator)])
+    dock_coordinators = hass.data[DOMAIN][config_entry.entry_id][
+        UNFOLDED_CIRCLE_DOCK_COORDINATORS
+    ]
+    async_add_entities(
+        [
+            RebootButton(coordinator),
+            UpdateCheckButton(coordinator),
+        ]
+    )
+    for dock_coordinator in dock_coordinators:
+        async_add_entities(
+            [
+                RebootDockButton(dock_coordinator),
+                IdentifyDockButton(dock_coordinator),
+            ]
+        )
 
 
 class RebootButton(UnfoldedCircleEntity, ButtonEntity):
     """Representation of a Button entity."""
 
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = "mdi:gesture-tap-button"
-    _attr_device_class = ButtonDeviceClass.RESTART
-
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self.coordinator.api.serial_number}_restart_button"
-        self._attr_name = f"{self.coordinator.api.name} Restart Remote"
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_restart_button"
+        self._attr_name = "Restart"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = "mdi:gesture-tap-button"
+        self._attr_device_class = ButtonDeviceClass.RESTART
 
     @property
     def available(self) -> bool:
@@ -46,17 +65,15 @@ class RebootButton(UnfoldedCircleEntity, ButtonEntity):
 class UpdateCheckButton(UnfoldedCircleEntity, ButtonEntity):
     """Representation of a Button entity."""
 
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = "mdi:gesture-tap-button"
-    _attr_device_class = ButtonDeviceClass.UPDATE
-
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self.coordinator.api.serial_number}_update_check_button"
-        )
-        self._attr_name = f"{self.coordinator.api.name} Check for Update"
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_update_check_button"
+        self._attr_name = "Check for Update"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = "mdi:gesture-tap-button"
+        self._attr_device_class = ButtonDeviceClass.UPDATE
 
     @property
     def available(self) -> bool:
@@ -67,3 +84,49 @@ class UpdateCheckButton(UnfoldedCircleEntity, ButtonEntity):
         """Press the button."""
         await self.coordinator.api.get_remote_force_update_information()
         self.async_write_ha_state()
+
+
+class RebootDockButton(UnfoldedCircleDockEntity, ButtonEntity):
+    """Representation of a Button entity."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self.coordinator.api.model_number}_{self.coordinator.api.serial_number}_restart_button"
+        self._attr_name = "Restart"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = "mdi:gesture-tap-button"
+        self._attr_device_class = ButtonDeviceClass.RESTART
+        self._attr_has_entity_name = True
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.coordinator.api.send_command("REBOOT")
+
+
+class IdentifyDockButton(UnfoldedCircleDockEntity, ButtonEntity):
+    """Representation of a Button entity."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self.coordinator.api.model_number}_{self.coordinator.api.serial_number}_identify_button"
+        self._attr_name = "Identify"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_icon = "mdi:gesture-tap-button"
+        self._attr_device_class = ButtonDeviceClass.IDENTIFY
+        self._attr_has_entity_name = True
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self.coordinator.api.send_command("IDENTIFY")

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -45,12 +45,10 @@ from .websocket import SubscriptionEvent, UCWebsocketClient
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required("host"): str,
-        vol.Required("pin"): str,
-    }
-)
+STEP_USER_DATA_SCHEMA = vol.Schema({
+    vol.Required("host"): str,
+    vol.Required("pin"): str,
+})
 
 STEP_ZEROCONF_DATA_SCHEMA = vol.Schema({vol.Required("pin"): str})
 
@@ -364,14 +362,12 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
         remote_name = "Remote Two"
         if "RemoteThree" in hostname:
             remote_name = "Remote Three"
-        self.discovery_info.update(
-            {
-                CONF_HOST: host,
-                CONF_PORT: port,
-                CONF_NAME: f"{remote_name} ({host})",
-                CONF_MAC: mac_address,
-            }
-        )
+        self.discovery_info.update({
+            CONF_HOST: host,
+            CONF_PORT: port,
+            CONF_NAME: f"{remote_name} ({host})",
+            CONF_MAC: mac_address,
+        })
 
         _LOGGER.debug(
             "Unfolded circle remote found %s %s %s :", mac_address, host, discovery_info
@@ -395,15 +391,13 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
         if is_simulator:
             device_name = f"{device_name} Simulator"
 
-        self.context.update(
-            {
-                "title_placeholders": {"name": device_name},
-                "configuration_url": (
-                    f"http://{discovery_info.host}:{discovery_info.port}/configurator/"
-                ),
-                "product": "Product",
-            }
-        )
+        self.context.update({
+            "title_placeholders": {"name": device_name},
+            "configuration_url": (
+                f"http://{discovery_info.host}:{discovery_info.port}/configurator/"
+            ),
+            "product": "Product",
+        })
 
         _LOGGER.debug(
             "Unfolded Circle Zeroconf Creating: %s %s", mac_address, discovery_info
@@ -606,28 +600,26 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="media_player",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_GLOBAL_MEDIA_ENTITY,
-                        default=self.config_entry.options.get(
-                            CONF_GLOBAL_MEDIA_ENTITY, True
-                        ),
-                    ): bool,
-                    vol.Optional(
-                        CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,
-                        default=self.config_entry.options.get(
-                            CONF_ACTIVITY_GROUP_MEDIA_ENTITIES, False
-                        ),
-                    ): bool,
-                    vol.Optional(
-                        CONF_ACTIVITY_MEDIA_ENTITIES,
-                        default=self.config_entry.options.get(
-                            CONF_ACTIVITY_MEDIA_ENTITIES, False
-                        ),
-                    ): bool,
-                }
-            ),
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_GLOBAL_MEDIA_ENTITY,
+                    default=self.config_entry.options.get(
+                        CONF_GLOBAL_MEDIA_ENTITY, True
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,
+                    default=self.config_entry.options.get(
+                        CONF_ACTIVITY_GROUP_MEDIA_ENTITIES, False
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ACTIVITY_MEDIA_ENTITIES,
+                    default=self.config_entry.options.get(
+                        CONF_ACTIVITY_MEDIA_ENTITIES, False
+                    ),
+                ): bool,
+            }),
             last_step=True,
         )
 
@@ -639,22 +631,20 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="activities",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(
-                        CONF_ACTIVITIES_AS_SWITCHES,
-                        default=self.config_entry.options.get(
-                            CONF_ACTIVITIES_AS_SWITCHES, False
-                        ),
-                    ): bool,
-                    vol.Optional(
-                        CONF_SUPPRESS_ACTIVITIY_GROUPS,
-                        default=self.config_entry.options.get(
-                            CONF_SUPPRESS_ACTIVITIY_GROUPS, False
-                        ),
-                    ): bool,
-                }
-            ),
+            data_schema=vol.Schema({
+                vol.Optional(
+                    CONF_ACTIVITIES_AS_SWITCHES,
+                    default=self.config_entry.options.get(
+                        CONF_ACTIVITIES_AS_SWITCHES, False
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_SUPPRESS_ACTIVITIY_GROUPS,
+                    default=self.config_entry.options.get(
+                        CONF_SUPPRESS_ACTIVITIY_GROUPS, False
+                    ),
+                ): bool,
+            }),
             last_step=False,
         )
 

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -363,13 +363,6 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_open_remote_page(self):
-        # TODO not used, to be tested (add a final link to remote's page)
-        return self.async_external_step(
-            step_id="finish",
-            url=f"http://{self._remote.derive_configuration_url}#/integrations-devices/hass.main",
-        )
-
     async def async_step_select_entities(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the selected entities to subscribe to."""
         errors: dict[str, str] = {}
@@ -443,6 +436,13 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
                             "select_entities": "Try again",
                             "finish": "Ignore this step and finish"
                         })
+                # Subscribe to the new entities
+                await asyncio.sleep(2)
+                # TODO : subscribe to the full entities list
+                #  GET the right integration intgId
+                #  GET /api/intg/instances/:intgId/entities?reload=true
+                #  POST /api/intg/instances/:intgId/entities
+
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error("Error while sending new entities to the remote %s (%s) %s",
                               self._remote.ip_address,
@@ -628,6 +628,12 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
                             "select_entities": "Try again",
                             "finish": "Ignore this step and finish"
                         })
+                
+                await asyncio.sleep(2)
+                # TODO : subscribe to the full entities list
+                #  GET the right integration intgId
+                #  GET /api/intg/instances/:intgId/entities?reload=true
+                #  POST /api/intg/instances/:intgId/entities
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error("Error while sending new entities to the remote %s (%s) %s",
                               self._remote.ip_address,

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -11,12 +11,7 @@ from homeassistant import config_entries
 from homeassistant.auth.models import TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_MAC,
-    CONF_NAME,
-    CONF_PORT,
-)
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
@@ -42,10 +37,9 @@ from .websocket import SubscriptionEvent, UCWebsocketClient
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required("host"): str,
-    vol.Required("pin"): str,
-})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {vol.Required("host"): str, vol.Required("pin"): str}
+)
 
 STEP_ZEROCONF_DATA_SCHEMA = vol.Schema({vol.Required("pin"): str})
 
@@ -250,9 +244,7 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
         self._remote: Remote | None = None
         self._websocket_client: UCWebsocketClient | None
 
-    async def validate_input(
-        self, data: dict[str, Any], host: str = ""
-    ) -> dict[str, Any]:
+    async def validate_input(self, data: dict[str, Any], host: str = "") -> dict[str, Any]:
         """Validate the user input allows us to connect.
 
         Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -29,7 +29,7 @@ from .const import (
     CONF_SERIAL,
     CONF_SUPPRESS_ACTIVITIY_GROUPS,
     DOMAIN,
-    HA_SUPPORTED_DOMAINS,
+    HA_SUPPORTED_DOMAINS, UC_HA_TOKEN_ID,
 )
 from .pyUnfoldedCircleRemote.const import AUTH_APIKEY_NAME, SIMULATOR_MAC_ADDRESS
 from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
@@ -273,15 +273,15 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
         await self._remote.get_remote_wifi_info()
 
         token = await generateToken(self.hass, self._remote.name)
-        token_id = f"{self._remote.name} id"
+        token_id = UC_HA_TOKEN_ID
         await self._remote.set_token_for_external_system(
             "homeassistant",
-            f"{self._remote.name} id",
+            token_id,
             token,
-            "Home Assistant",
-            "Home Assistant Long Lived Access Token",
+            "Home Assistant Access token",
+            "URL and long lived access token for Home Assistant WebSocket API",
             url,
-            "data",
+            "",
         )
 
         if not key:

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -12,7 +12,6 @@ from homeassistant.auth.models import TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import (
-    ATTR_FRIENDLY_NAME,
     CONF_HOST,
     CONF_MAC,
     CONF_NAME,
@@ -25,14 +24,12 @@ from homeassistant.helpers.network import get_url
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
-    selector,
 )
 
 from .const import (
     CONF_ACTIVITIES_AS_SWITCHES,
     CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,
     CONF_ACTIVITY_MEDIA_ENTITIES,
-    CONF_ADVANCED_CONFIGURATION,
     CONF_GLOBAL_MEDIA_ENTITY,
     CONF_SERIAL,
     CONF_SUPPRESS_ACTIVITIY_GROUPS,

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -27,5 +27,15 @@ HA_SUPPORTED_DOMAINS = [
     "remote",
 ]
 UC_HA_TOKEN_ID="ws-ha-api"
-UC_HA_SYSTEM="hass"
-UC_HA_DRIVER_ID="hass"
+
+DEBUG_UC_MSG=False
+
+TEST_HA_EXT=True
+
+UC_HA_SYSTEM = "hass"
+
+if TEST_HA_EXT:
+    UC_HA_DRIVER_ID = "hass2"
+else:
+    UC_HA_DRIVER_ID = "hass"
+

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -9,7 +9,6 @@ CONF_ACTIVITY_GROUP_MEDIA_ENTITIES = "activity_group_media_entities"
 CONF_GLOBAL_MEDIA_ENTITY = "global_media_entity"
 CONF_ACTIVITY_MEDIA_ENTITIES = "activity_media_entities"
 CONF_ACTIVITIES_AS_SWITCHES = "activities_as_switches"
-CONF_ADVANCED_CONFIGURATION = "advanced_configuration"
 CONF_SUPPRESS_ACTIVITIY_GROUPS = "suppress_activity_groups"
 DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
 UNFOLDED_CIRCLE_COORDINATOR = "unfolded_circle_coordinator"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -27,3 +27,4 @@ HA_SUPPORTED_DOMAINS = [
     "remote",
 ]
 UC_HA_TOKEN_ID="ws-ha-api"
+UC_HA_SYSTEM="hass"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -9,6 +9,7 @@ CONF_ACTIVITY_GROUP_MEDIA_ENTITIES = "activity_group_media_entities"
 CONF_GLOBAL_MEDIA_ENTITY = "global_media_entity"
 CONF_ACTIVITY_MEDIA_ENTITIES = "activity_media_entities"
 CONF_ACTIVITIES_AS_SWITCHES = "activities_as_switches"
+CONF_ADVANCED_CONFIGURATION = "advanced_configuration"
 CONF_SUPPRESS_ACTIVITIY_GROUPS = "suppress_activity_groups"
 DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
 UNFOLDED_CIRCLE_COORDINATOR = "unfolded_circle_coordinator"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -14,3 +14,4 @@ DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
 UNFOLDED_CIRCLE_COORDINATOR = "unfolded_circle_coordinator"
 UNFOLDED_CIRCLE_API = "unfolded_circle_api"
 UPDATE_ACTIVITY_SERVICE = "update_activity"
+HA_SUPPORTED_DOMAINS = ["button", "switch", "climate", "cover", "light", "media_player", "remote"]

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -12,14 +12,8 @@ CONF_ACTIVITIES_AS_SWITCHES = "activities_as_switches"
 CONF_SUPPRESS_ACTIVITIY_GROUPS = "suppress_activity_groups"
 DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
 UNFOLDED_CIRCLE_COORDINATOR = "unfolded_circle_coordinator"
+UNFOLDED_CIRCLE_DOCK_COORDINATORS = "unfolded_circle_dock_coordinators"
+UNFOLDED_CIRCLE_DOCK_COORDINATOR = "unfolded_circle_dock_coordinator"
 UNFOLDED_CIRCLE_API = "unfolded_circle_api"
 UPDATE_ACTIVITY_SERVICE = "update_activity"
-HA_SUPPORTED_DOMAINS = [
-    "button",
-    "switch",
-    "climate",
-    "cover",
-    "light",
-    "media_player",
-    "remote",
-]
+LEARN_IR_COMMAND_SERVICE = "learn_ir_command"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -26,3 +26,4 @@ HA_SUPPORTED_DOMAINS = [
     "media_player",
     "remote",
 ]
+UC_HA_TOKEN_ID="ws-ha-api"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -27,4 +27,6 @@ HA_SUPPORTED_DOMAINS = [
     "remote",
 ]
 UC_HA_TOKEN_ID="ws-ha-api"
+# TODO for testings
 UC_HA_SYSTEM="hass"
+UC_HA_DRIVER_ID="hass2"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -17,3 +17,12 @@ UNFOLDED_CIRCLE_DOCK_COORDINATOR = "unfolded_circle_dock_coordinator"
 UNFOLDED_CIRCLE_API = "unfolded_circle_api"
 UPDATE_ACTIVITY_SERVICE = "update_activity"
 LEARN_IR_COMMAND_SERVICE = "learn_ir_command"
+HA_SUPPORTED_DOMAINS = [
+    "button",
+    "switch",
+    "climate",
+    "cover",
+    "light",
+    "media_player",
+    "remote",
+]

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -27,6 +27,5 @@ HA_SUPPORTED_DOMAINS = [
     "remote",
 ]
 UC_HA_TOKEN_ID="ws-ha-api"
-# TODO for testings
 UC_HA_SYSTEM="hass"
-UC_HA_DRIVER_ID="hass2"
+UC_HA_DRIVER_ID="hass"

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -15,4 +15,12 @@ DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
 UNFOLDED_CIRCLE_COORDINATOR = "unfolded_circle_coordinator"
 UNFOLDED_CIRCLE_API = "unfolded_circle_api"
 UPDATE_ACTIVITY_SERVICE = "update_activity"
-HA_SUPPORTED_DOMAINS = ["button", "switch", "climate", "cover", "light", "media_player", "remote"]
+HA_SUPPORTED_DOMAINS = [
+    "button",
+    "switch",
+    "climate",
+    "cover",
+    "light",
+    "media_player",
+    "remote",
+]

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from pyUnfoldedCircleRemote.remote import Remote
-from pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
+from .pyUnfoldedCircleRemote.remote import Remote
+from .pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
 
 from .const import DEVICE_SCAN_INTERVAL, DOMAIN
 from .websocket import UCClientInterface, async_register_websocket_commands

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -7,27 +7,23 @@ import logging
 from typing import Any
 from urllib.error import HTTPError
 
-
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from .pyUnfoldedCircleRemote.remote import Remote
-from .pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
 
 from .const import DEVICE_SCAN_INTERVAL, DOMAIN
+from .pyUnfoldedCircleRemote.remote import Remote
+from .pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
 from .websocket import UCWebsocketClient
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class UnfoldedCircleRemoteCoordinator(
-    DataUpdateCoordinator[dict[str, Any]]
-):
+class UnfoldedCircleRemoteCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Data update coordinator for an Unfolded Circle Remote device."""
 
     # List of events to subscribe to the websocket

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -20,7 +20,7 @@ from pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
 from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
 from pyUnfoldedCircleRemote.dock import Dock
 
-from .const import DEVICE_SCAN_INTERVAL, DOMAIN
+from .const import DEVICE_SCAN_INTERVAL, DOMAIN, DEBUG_UC_MSG
 from .websocket import UCWebsocketClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,7 +126,8 @@ class UnfoldedCircleCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             debug_info.append(
                 f" - Player {media_entity.name} ({media_entity.id}) : {media_entity.state}"
             )
-        _LOGGER.debug("UC2 debug structure\n%s", "\n".join(debug_info))
+        if DEBUG_UC_MSG:
+            _LOGGER.debug("UC2 debug structure\n%s", "\n".join(debug_info))
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Get the latest data from the Unfolded Circle Remote."""

--- a/custom_components/unfoldedcircle/entity.py
+++ b/custom_components/unfoldedcircle/entity.py
@@ -6,6 +6,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import UnfoldedCircleRemoteCoordinator
 from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+from .coordinator import UnfoldedCircleDockCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry):
@@ -14,7 +15,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry):
 
 
 class UnfoldedCircleEntity(CoordinatorEntity[UnfoldedCircleRemoteCoordinator]):
-    """Common entity class for all UC entities"""
+    """Common entity class for all Unfolded Circle entities"""
 
     def __init__(self, coordinator) -> None:
         """Initialize Unfolded Circle Sensor."""
@@ -28,7 +29,11 @@ class UnfoldedCircleEntity(CoordinatorEntity[UnfoldedCircleRemoteCoordinator]):
         return DeviceInfo(
             identifiers={
                 # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, self.coordinator.api.serial_number)
+                (
+                    DOMAIN,
+                    self.coordinator.api.model_number,
+                    self.coordinator.api.serial_number,
+                )
             },
             name=self.coordinator.api.name,
             manufacturer=self.coordinator.api.manufacturer,
@@ -40,4 +45,39 @@ class UnfoldedCircleEntity(CoordinatorEntity[UnfoldedCircleRemoteCoordinator]):
 
     @property
     def should_poll(self) -> bool:
+        """Should the entity poll for updates?"""
         return False
+
+
+class UnfoldedCircleDockEntity(CoordinatorEntity[UnfoldedCircleDockCoordinator]):
+    """Common entity class for all Unfolded Circle Dock entities"""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize Unfolded Circle Sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self.coordinator.entities.append(self)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={
+                (
+                    DOMAIN,
+                    self.coordinator.api.model_number,
+                    self.coordinator.api.serial_number,
+                )
+            },
+            name=self.coordinator.api.name,
+            manufacturer=self.coordinator.api.manufacturer,
+            model=self.coordinator.api.model_name,
+            sw_version=self.coordinator.api.software_version,
+            hw_version=self.coordinator.api.hardware_revision,
+            configuration_url=self.coordinator.api.remote_configuration_url,
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """Should the entity poll for updates?"""
+        return True

--- a/custom_components/unfoldedcircle/helpers.py
+++ b/custom_components/unfoldedcircle/helpers.py
@@ -1,0 +1,23 @@
+"""Helper functions for Unfolded Circle Devices"""
+
+import asyncio
+import logging
+from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
+from pyUnfoldedCircleRemote.remote import Remote
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def validate_dock_password(remote_api: Remote, user_info) -> bool:
+    """Validate"""
+    dock = remote_api.get_dock_by_id(user_info.get("id"))
+
+    websocket = DockWebsocket(
+        dock._ws_endpoint,
+        api_key=dock.apikey,
+        dock_password=user_info.get("password"),
+    )
+    try:
+        return await asyncio.create_task(websocket.is_password_valid())
+    except Exception as ex:
+        _LOGGER.error("Error occurred when validating dock: %s %s", dock.name, ex)

--- a/custom_components/unfoldedcircle/icons.json
+++ b/custom_components/unfoldedcircle/icons.json
@@ -1,5 +1,6 @@
 {
   "services": {
-    "update_activity": "mdi:movie-open-edit-outline"
+    "update_activity": "mdi:movie-open-edit-outline",
+    "learn_ir_command": "mdi:remote"
   }
 }

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -9,8 +9,8 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
-  "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.10.1"],
+  "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.11.3"],
   "ssdp": [],
-  "version": "0.10.0",
+  "version": "0.11.0",
   "zeroconf": ["_uc-remote._tcp.local."]
 }

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["network", "zeroconf"],
   "documentation": "https://github.com/JackJPowell/hass-unfoldedcircle",
   "homekit": {},
-  "integration_type": "hub",
+  "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.10.1"],

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["network", "zeroconf"],
   "documentation": "https://github.com/JackJPowell/hass-unfoldedcircle",
   "homekit": {},
-  "integration_type": "device",
+  "integration_type": "hub",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.10.1"],

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
-  "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.10.0"],
+  "requirements": ["websockets==12.0", "pyUnfoldedCircleRemote==0.10.1"],
   "ssdp": [],
   "version": "0.10.0",
   "zeroconf": ["_uc-remote._tcp.local."]

--- a/custom_components/unfoldedcircle/media_player.py
+++ b/custom_components/unfoldedcircle/media_player.py
@@ -19,8 +19,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UndefinedType
 from homeassistant.util import utcnow
-from .pyUnfoldedCircleRemote.const import RemoteUpdateType
-from .pyUnfoldedCircleRemote.remote import Activity, ActivityGroup, UCMediaPlayerEntity
 
 from .const import (
     CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,
@@ -30,6 +28,8 @@ from .const import (
     UNFOLDED_CIRCLE_COORDINATOR,
 )
 from .entity import UnfoldedCircleEntity
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.remote import Activity, ActivityGroup, UCMediaPlayerEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/unfoldedcircle/media_player.py
+++ b/custom_components/unfoldedcircle/media_player.py
@@ -19,8 +19,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UndefinedType
 from homeassistant.util import utcnow
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
-from pyUnfoldedCircleRemote.remote import Activity, ActivityGroup, UCMediaPlayerEntity
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.remote import Activity, ActivityGroup, UCMediaPlayerEntity
 
 from .const import (
     CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/const.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/const.py
@@ -8,6 +8,7 @@ WS_RECONNECTION_DELAY = 30  # seconds
 ZEROCONF_TIMEOUT = 3
 ZEROCONF_SERVICE_TYPE = "_uc-remote._tcp.local."
 SIMULATOR_MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
+DEFAULT_INTEGRATION_ID = "hass.main"
 
 SYSTEM_COMMANDS = [
     "STANDBY",

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/const.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/const.py
@@ -8,7 +8,7 @@ WS_RECONNECTION_DELAY = 30  # seconds
 ZEROCONF_TIMEOUT = 3
 ZEROCONF_SERVICE_TYPE = "_uc-remote._tcp.local."
 SIMULATOR_MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
-DEFAULT_INTEGRATION_ID = "hass.main"
+DEFAULT_HA_INTEGRATION_ID = "hass.main"
 
 SYSTEM_COMMANDS = [
     "STANDBY",

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock.py
@@ -1,0 +1,589 @@
+"""Module to interact with the Unfolded Circle Remote Two Dock."""
+
+import logging
+import asyncio
+import re
+import json
+from enum import Enum
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DockCommand(Enum):
+    SET_LED_BRIGHTNESS = "SET_LED_BRIGHTNESS"
+    IDENTIFY = "IDENTIFY"
+    REBOOT = "REBOOT"
+
+
+class HTTPError(BaseException):
+    """Raised when an HTTP operation fails."""
+
+    def __init__(self, status_code, message) -> None:
+        """Raise HTTP Error."""
+        self.status_code = status_code
+        self.message = message
+        super().__init__(self.message, self.status_code)
+
+
+class AuthenticationError(BaseException):
+    """Raised when HTTP login fails."""
+
+
+class SystemCommandNotFound(BaseException):
+    """Raised when an invalid system command is supplied."""
+
+    def __init__(self, message) -> None:
+        """Raise command no found error."""
+        self.message = message
+        super().__init__(self.message)
+
+
+class ExternalSystemNotRegistered(BaseException):
+    """Raised when an unregistered external system is supplied."""
+
+    def __init__(self, message) -> None:
+        """Raise command no found error."""
+        self.message = message
+        super().__init__(self.message)
+
+
+class InvalidIRFormat(BaseException):
+    """Raised when invalid or insufficient IR details are passed."""
+
+    def __init__(self, message) -> None:
+        """Raise invalid IR format error."""
+        self.message = message
+        super().__init__(self.message)
+
+
+class NoEmitterFound(BaseException):
+    """Raised when no emitter could be identified from criteria given."""
+
+    def __init__(self, message) -> None:
+        """Raise invalid emitter error."""
+        self.message = message
+        super().__init__(self.message)
+
+
+class ApiKeyNotFound(BaseException):
+    """Raised when API Key with given name can't be found.
+
+    Attributes:
+        name -- Name of the API Key
+        message -- explanation of the error
+    """
+
+    def __init__(self, name, message="API key name not found") -> None:
+        """Raise API key not found."""
+        self.name = name
+        self.message = message
+        super().__init__(self.message)
+
+
+class Dock:
+    """Unfolded Circle Dock Class."""
+
+    def __init__(
+        self,
+        dock_id: str,
+        apikey: str,
+        remote_endpoint: str,
+        remote_configuration_url: str,
+        name: str = "",
+        ws_url: str = "",
+        is_active: bool = False,
+        model_name: str = "",
+        hardware_revision: str = "",
+        serial_number: str = "",
+        led_brightness: int = 0,
+        ethernet_led_brightness: int = 0,
+        software_version: str = "",
+        state: str = "",
+        is_learning_active: bool = False,
+    ) -> None:
+        """Create a new UC Remote Object."""
+
+        self._ws_endpoint = ws_url
+        self._id = dock_id
+        self._name = name
+        self._password = ""
+        self._host_name = ""
+        self._software_version = software_version
+        self._serial_number = serial_number
+        self._model_name = model_name
+        self._hardware_revision = hardware_revision
+        self._model_number = ""
+        self._manufacturer = "Unfolded Circle"
+        self._mac_address = dock_id.lower().removeprefix("uc-dock-")
+        self._ip_address = ""
+        self._is_active = is_active
+        self._led_brightness = led_brightness
+        self._ethernet_led_brightness = ethernet_led_brightness
+        self._state = state
+        self._is_learning_active = is_learning_active
+        self._learned_code = {}
+        self._codesets = []
+        self._token = ""
+        self._description = ""
+        self._check_for_updates = False
+        self._automatic_updates = False
+        self._available_update = []
+        self._latest_software_version = ""
+        self._release_notes_url = ""
+        self._release_notes = ""
+        self._remotes = []
+        self._remotes_complete = []
+        self.endpoint = remote_endpoint
+        self.apikey = apikey
+        self._remote_configuration_url = remote_configuration_url
+        self.websocket = ""
+
+    @property
+    def name(self):
+        """Name of the dock."""
+        return self._name or "Unfolded Circle Dock"
+
+    @property
+    def id(self):
+        """id of the dock."""
+        return self._id
+
+    @property
+    def host_name(self):
+        """host_name of the dock."""
+        return self._host_name
+
+    @property
+    def software_version(self):
+        """software version of the dock."""
+        return self._software_version
+
+    @property
+    def serial_number(self):
+        """serial number of the dock."""
+        return self._serial_number
+
+    @property
+    def model_name(self):
+        """model_name of the dock."""
+        if self._model_name == "UCD2":
+            return "Dock Two"
+        return self._model_name
+
+    @property
+    def hardware_revision(self):
+        """hardware_revision of the dock."""
+        return self._hardware_revision
+
+    @property
+    def model_number(self):
+        """model_number of the dock."""
+        return self._model_number
+
+    @property
+    def manufacturer(self):
+        """manufacturer of the dock."""
+        return self._manufacturer
+
+    @property
+    def mac_address(self):
+        """mac_address of the dock."""
+        return self._mac_address
+
+    @property
+    def ip_address(self):
+        """ip_address of the dock."""
+        return self._ip_address
+
+    @property
+    def is_active(self):
+        """Is the dock active"""
+        return self._is_active
+
+    @property
+    def remotes(self):
+        """List of defined remotes."""
+        return self._remotes
+
+    @property
+    def remotes_complete(self):
+        """List of defined remotes_complete."""
+        return self._remotes_complete
+
+    @property
+    def codesets(self):
+        """List of defined codesets."""
+        return self._codesets
+
+    @property
+    def led_brightness(self):
+        """led_brightness of the dock."""
+        return self._led_brightness
+
+    @property
+    def ethernet_led_brightness(self):
+        """ethernet_led_brightness of the dock."""
+        return self._ethernet_led_brightness
+
+    @property
+    def state(self):
+        """state of the dock."""
+        return self._state
+
+    @property
+    def is_learning_active(self):
+        """is_learning_active of the dock."""
+        return self._is_learning_active
+
+    @property
+    def learned_code(self):
+        """Most recent learned code."""
+        return self._learned_code
+
+    @property
+    def token(self):
+        """token of the dock."""
+        return self._token
+
+    @property
+    def description(self):
+        """description of the dock."""
+        return self._description
+
+    @property
+    def check_for_updates(self):
+        """check_for_updates of the dock."""
+        return self._check_for_updates
+
+    @property
+    def automatic_updates(self):
+        """automatic_updates of the dock."""
+        return self._automatic_updates
+
+    @property
+    def available_update(self):
+        """available_update of the dock."""
+        return self._available_update
+
+    @property
+    def latest_software_version(self):
+        """latest_software_version of the dock."""
+        return self._latest_software_version
+
+    @property
+    def release_notes_url(self):
+        """release_notes_url of the dock."""
+        return self._release_notes_url
+
+    @property
+    def release_notes(self):
+        """release_notes of the dock."""
+        return self._release_notes
+
+    @property
+    def remote_configuration_url(self):
+        """remote_configuration_url of the dock."""
+        return self._remote_configuration_url
+
+    @property
+    def ws_endpoint(self):
+        """ws_endpoint of the dock."""
+        return self._ws_endpoint
+
+    @property
+    def password(self):
+        """password of the dock."""
+        return self._password
+
+    @property
+    def has_password(self):
+        """returns true if password of the dock is set."""
+        return self._password != ""
+
+    ### URL Helpers ###
+    def validate_url(self, uri):
+        """Validate passed in URL and attempts to correct api endpoint if path isn't supplied."""
+        if re.search("^http.*", uri) is None:
+            uri = (
+                "http://" + uri
+            )  # Normalize to absolute URLs so urlparse will parse the way we want
+        parsed_url = urlparse(uri)
+        # valdation = set(uri)
+        if parsed_url.scheme == "":
+            uri = "http://" + uri
+        if parsed_url.path == "/":  # Only host supplied
+            uri = uri + "api/"
+            return uri
+        if parsed_url.path == "":
+            uri = uri + "/api/"
+            return uri
+        if (
+            parsed_url.path[-1] != "/"
+        ):  # User supplied an endpoint, make sure it has a trailing slash
+            uri = uri + "/"
+        return uri
+
+    def derive_configuration_url(self) -> str:
+        """Derive configuration url from endpoint url."""
+        parsed_url = urlparse(self.endpoint)
+        self.configuration_url = (
+            f"{parsed_url.scheme}://{parsed_url.netloc}/configurator/"
+        )
+        return self.configuration_url
+
+    def url(self, path="/") -> str:
+        """Join path with base url."""
+        return urljoin(self.endpoint, path)
+
+    @staticmethod
+    def url_is_secure(url) -> bool:
+        """Returns true if the configuration url is using a secure protocol"""
+        parsed_url = urlparse(url)
+        if parsed_url.scheme == "https":
+            return True
+        return False
+
+    ### HTTP methods ###
+    def client(self) -> aiohttp.ClientSession:
+        """Create a aiohttp client object with needed headers and defaults."""
+        if self.apikey:
+            headers = {
+                "Authorization": "Bearer " + self.apikey,
+                "Accept": "application/json",
+            }
+            return aiohttp.ClientSession(
+                headers=headers, timeout=aiohttp.ClientTimeout(total=5)
+            )
+
+    async def can_connect(self) -> bool:
+        """Validate we can communicate with the remote given the supplied information."""
+        async with (
+            self.client() as session,
+            session.head(self.url("activities")) as response,
+        ):
+            if response.status == 401:
+                raise AuthenticationError
+            return response.status == 200
+
+    async def raise_on_error(self, response):
+        """Raise an HTTP error if the response returns poorly."""
+        if not response.ok:
+            content = await response.json()
+            msg = f"{response.status} Request: {content['code']} Reason: {content['message']}"
+            raise HTTPError(response.status, msg)
+        return response
+
+    async def get_info(self) -> str:
+        """Get dock information."""
+        async with (
+            self.client() as session,
+            session.get(self.url(f"docks/devices/{self.id}")) as response,
+        ):
+            await self.raise_on_error(response)
+            information = await response.json()
+            self._name = information.get("name")
+            self._ws_endpoint = information.get("resolved_ws_url")
+            self._is_active = information.get("active")
+            self._model_number = information.get("model")
+            self._hardware_revision = information.get("revision")
+            self._serial_number = information.get("serial")
+            self._led_brightness = information.get("led_brightness")
+            self._ethernet_led_brightness = information.get("eth_led_brightness")
+            self._software_version = information.get("version")
+            self._state = information.get("state")
+            self._is_learning_active = information.get("learning_active")
+
+            return information
+
+    async def get_update_status(self) -> str:
+        """Get dock update information"""
+        async with (
+            self.client() as session,
+            session.get(self.url(f"docks/devices/{self.id}/update")) as response,
+        ):
+            await self.raise_on_error(response)
+            information = await response.json()
+            self._latest_software_version = information.get("version")
+            self._available_update = information.get("update_available")
+            self._check_for_updates = information.get("update_check_enabled")
+
+            return information
+
+    async def start_ir_learning(self) -> str:
+        """Start an IR Learning Session"""
+        async with (
+            self.client() as session,
+            session.put(self.url(f"ir/emitters/{self.id}/learn")) as response,
+        ):
+            await self.raise_on_error(response)
+            information = await response.json()
+
+            return information
+
+    async def stop_ir_learning(self) -> str:
+        """Stop an IR learning session"""
+        async with (
+            self.client() as session,
+            session.delete(self.url(f"ir/emitters/{self.id}/learn")) as response,
+        ):
+            await self.raise_on_error(response)
+            information = await response.json()
+
+            return information
+
+    async def get_remotes(self) -> list:
+        """Get list of remotes defined. (IR Remotes as defined by Unfolded Circle)."""
+        remote_data = {}
+        async with (
+            self.client() as session,
+            session.get(self.url("remotes")) as response,
+        ):
+            await self.raise_on_error(response)
+            remotes = await response.json()
+            for remote in remotes:
+                if remote.get("enabled") is True:
+                    remote_data = {
+                        "name": remote.get("name").get("en"),
+                        "entity_id": remote.get("entity_id"),
+                    }
+                    self._remotes.append(remote_data.copy())
+            return self._remotes
+
+    async def get_remotes_complete(self) -> list:
+        """Get list of remotes defined. (IR Remotes as defined by Unfolded Circle)."""
+        if not self.remotes:
+            await self.get_remotes()
+
+        for remote in self.remotes:
+            entity_id = remote.get("entity_id")
+            async with (
+                self.client() as session,
+                session.get(self.url(f"remotes/{entity_id}")) as response,
+            ):
+                await self.raise_on_error(response)
+                remote_info = await response.json()
+                self._remotes_complete.append(remote_info.copy())
+        return self._remotes_complete
+
+    async def get_custom_codesets(self) -> list:
+        """Get list of custom ir codesets."""
+        async with (
+            self.client() as session,
+            session.get(self.url("ir/codes/custom")) as response,
+        ):
+            await self.raise_on_error(response)
+            codesets = await response.json()
+            self._codesets = codesets
+            return self._codesets
+
+    async def create_remote(
+        self, name: str, device: str, description: str, icon: str = "uc:movie"
+    ) -> dict:
+        """Create a new remote codeset. (IR Remotes as defined by Unfolded Circle)."""
+        remote_data = {
+            "name": {"en": f"{name}"},
+            "icon": f"{icon}",
+            "description": {"en": f"{description}"},
+            "custom_codeset": {
+                "manufacturer_id": "custom",
+                "device_name": f"{device}",
+                "device_type": "various",
+            },
+        }
+        async with (
+            self.client() as session,
+            session.post(self.url("remotes"), json=remote_data) as response,
+        ):
+            await self.raise_on_error(response)
+            return await response.json()
+
+    async def add_remote_command_to_codeset(
+        self,
+        remote_entity_id: str,
+        command_id: str,
+        value: str,
+        ir_format: str,
+        update_if_exists: bool = True,
+    ) -> list:
+        """Get list of remote codesets."""
+        ir_data = {"value": f"{value}", "format": f"{ir_format}"}
+        async with (
+            self.client() as session,
+            session.post(
+                self.url(f"remotes/{remote_entity_id}/ir/{command_id}"),
+                json=ir_data,
+            ) as response,
+        ):
+            codeset = await response.json()
+            if response.status == 422:
+                if update_if_exists:
+                    codeset = await self.update_remote_command_in_codeset(
+                        remote_entity_id, command_id, value, ir_format
+                    )
+                    return codeset
+                else:
+                    await self.raise_on_error(response)
+
+            if response.ok:
+                return codeset
+
+    async def update_remote_command_in_codeset(
+        self,
+        remote_entity_id: str,
+        command_id: str,
+        value: str,
+        ir_format: str,
+    ) -> list:
+        """Update command in remote codesets."""
+        ir_data = {"value": f"{value}", "format": f"{ir_format}"}
+        async with (
+            self.client() as session,
+            session.patch(
+                self.url(f"remotes/{remote_entity_id}/ir/{command_id}"),
+                json=ir_data,
+            ) as response,
+        ):
+            await self.raise_on_error(response)
+            return await response.json()
+
+    async def send_command(
+        self, command: DockCommand, command_value: str = None
+    ) -> str:
+        """Send a command to the dock"""
+        payload = {"command": f"{command}"}
+        if command_value:
+            payload = {"command": f"{command}", "value": f"{command_value}"}
+        async with (
+            self.client() as session,
+            session.post(
+                self.url(f"docks/devices/{self.id}/command"), json=payload
+            ) as response,
+        ):
+            await self.raise_on_error(response)
+            return await response.json()
+
+    def update_from_message(self, message: any) -> None:
+        """Update internal data from received websocket messages"""
+        data = json.loads(message)
+        _LOGGER.debug("RC2 received websocket message %s", data)
+        try:
+            if data["type"] == "auth_required":
+                _LOGGER.debug("auth is required")
+            if data["msg"] == "ir_receive":
+                self._learned_code = data.get("ir_code")
+        except Exception:
+            pass
+
+    async def update(self):
+        """Updates all information about the remote."""
+        _LOGGER.debug("Unfoldded circle remote update data")
+        group = asyncio.gather(
+            self.get_info(),
+            self.get_update_status(),
+        )
+        await group
+
+        _LOGGER.debug("Unfoldded circle remote data updated")

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock_websocket.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock_websocket.py
@@ -1,0 +1,156 @@
+"""Unfolded Circle Dock Web Socket Module"""
+
+import asyncio
+import json
+import logging
+from typing import Callable, Coroutine
+import websockets
+
+from .websocket import Websocket
+from .const import WS_RECONNECTION_DELAY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    """Logger class for websocket for debugging.
+    Add connection ID and client IP address to websockets logs."""
+
+    def process(self, msg, kwargs):
+        try:
+            websocket = kwargs["extra"]["websocket"]
+        except KeyError:
+            return msg, kwargs
+        return f"{websocket.id} {msg}", kwargs
+
+
+class DockWebsocket(Websocket):
+    """Web Socket Class for Unfolded Circle Dock"""
+
+    def __init__(
+        self, api_url: str, api_key: str = None, dock_password: str = None
+    ) -> None:
+        super().__init__(api_url, api_key, dock_password)
+        self.endpoint = api_url
+        self.awaits_password = True
+
+    async def init_websocket(
+        self,
+        receive_callback: Callable[..., Coroutine],
+        reconnection_callback: Callable[..., Coroutine],
+    ):
+        """Initialize websocket connection with the dock password."""
+        if self.dock_password:
+            await self.close_websocket()
+            _LOGGER.debug(
+                "UnfoldedCircleDock websocket init connection to %s",
+                self.endpoint,
+            )
+
+            first = True
+            async for websocket in websockets.connect(
+                self.endpoint,
+                ping_interval=30,
+                ping_timeout=30,
+                close_timeout=20,
+            ):
+                try:
+                    _LOGGER.debug("UnfoldedCircleDock websocket connection initialized")
+                    self.websocket = websocket
+
+                    if first:
+                        first = False
+                    else:
+                        # Call reconnection callback after reconnection success:
+                        # useful to extract fresh information with APIs after a
+                        # long period of disconnection (sleep)
+                        asyncio.ensure_future(reconnection_callback())
+
+                    while True:
+                        async for message in websocket:
+                            try:
+                                data = json.loads(message)
+                                _LOGGER.debug("RC2 received websocket message %s", data)
+                                if data["type"] == "auth_required":
+                                    asyncio.ensure_future(
+                                        self.send_message(
+                                            {
+                                                "type": "auth",
+                                                "token": f"{self.dock_password}",
+                                            }
+                                        )
+                                    )
+                                asyncio.ensure_future(receive_callback(self, message))
+                            except Exception as ex:
+                                _LOGGER.debug(
+                                    "UnfoldedCircleRemote exception in websocket receive callback %s",
+                                    ex,
+                                )
+                except websockets.ConnectionClosed as error:
+                    _LOGGER.debug(
+                        "UnfoldedCircleRemote websocket closed. Waiting before reconnecting... %s",
+                        error,
+                    )
+                    await asyncio.sleep(WS_RECONNECTION_DELAY)
+                    continue
+            _LOGGER.error(
+                "UnfoldedCircleRemote exiting init_websocket, this is not normal"
+            )
+
+    async def is_password_valid(
+        self,
+    ):
+        """Initialize websocket connection with the dock password."""
+        if self.dock_password:
+            await self.close_websocket()
+            _LOGGER.debug(
+                "UnfoldedCircleDock websocket init connection to %s",
+                self.endpoint,
+            )
+
+            async for websocket in websockets.connect(
+                self.endpoint,
+                ping_interval=30,
+                ping_timeout=30,
+                close_timeout=20,
+            ):
+                try:
+                    _LOGGER.debug("UnfoldedCircleDock websocket connection initialized")
+                    self.websocket = websocket
+
+                    while self.awaits_password:
+                        async for message in websocket:
+                            try:
+                                data = json.loads(message)
+                                _LOGGER.debug("RC2 received websocket message %s", data)
+                                if data["type"] == "auth_required":
+                                    asyncio.ensure_future(
+                                        self.send_message(
+                                            {
+                                                "type": "auth",
+                                                "token": f"{self.dock_password}",
+                                            }
+                                        )
+                                    )
+                                if data["type"] == "authentication":
+                                    await self.close_websocket()
+                                    if data["code"] == 200:
+                                        return True
+                                    return False
+
+                            except Exception as ex:
+                                _LOGGER.debug(
+                                    "UnfoldedCircleRemote exception in websocket receive callback %s",
+                                    ex,
+                                )
+                except websockets.ConnectionClosed as error:
+                    _LOGGER.debug(
+                        "UnfoldedCircleRemote websocket closed. Waiting before reconnecting... %s",
+                        error,
+                    )
+                    await asyncio.sleep(WS_RECONNECTION_DELAY)
+                    continue
+            _LOGGER.error(
+                "UnfoldedCircleRemote exiting init_websocket, this is not normal"
+            )
+        return False

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -16,12 +16,13 @@ import zeroconf
 from .const import (
     AUTH_APIKEY_NAME,
     AUTH_USERNAME,
+    DEFAULT_HA_INTEGRATION_ID,
     SIMULATOR_MAC_ADDRESS,
     SYSTEM_COMMANDS,
     ZEROCONF_SERVICE_TYPE,
     ZEROCONF_TIMEOUT,
     RemotePowerModes,
-    RemoteUpdateType, DEFAULT_HA_INTEGRATION_ID,
+    RemoteUpdateType,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -383,7 +384,7 @@ class Remote:
         """Validate passed in URL and attempts to correct api endpoint if path isn't supplied."""
         if re.search("^http.*", uri) is None:
             uri = (
-                    "http://" + uri
+                "http://" + uri
             )  # Normalize to absolute URLs so urlparse will parse the way we want
         parsed_url = urlparse(uri)
         # valdation = set(uri)
@@ -396,7 +397,7 @@ class Remote:
             uri = uri + "/api/"
             return uri
         if (
-                parsed_url.path[-1] != "/"
+            parsed_url.path[-1] != "/"
         ):  # User supplied an endpoint, make sure it has a trailing slash
             uri = uri + "/"
         return uri
@@ -510,8 +511,8 @@ class Remote:
             return await response.json()
 
     async def get_tokens_for_external_system(
-            self,
-            system: str,
+        self,
+        system: str,
     ) -> str:
         """Lists available token information for the given system"""
 
@@ -525,14 +526,14 @@ class Remote:
         raise ExternalSystemNotRegistered
 
     async def set_token_for_external_system(
-            self,
-            system: str,
-            token_id: str,
-            token: str,
-            name: str = "Home Assistant Integration",
-            description: str = None,
-            url: str = None,
-            data: str = None,
+        self,
+        system: str,
+        token_id: str,
+        token: str,
+        name: str = "Home Assistant Integration",
+        description: str = None,
+        url: str = None,
+        data: str = None,
     ) -> str:
         """This method allows the external system to automatically provide the access
         token for the corresponding R2 integration instead of forcing the user to type it in.
@@ -570,14 +571,14 @@ class Remote:
         raise ExternalSystemNotRegistered
 
     async def update_token_for_external_system(
-            self,
-            system: str,
-            token_id: str,
-            token: str,
-            name: str = "Home Assistant Integration",
-            description: str = None,
-            url: str = None,
-            data: str = None,
+        self,
+        system: str,
+        token_id: str,
+        token: str,
+        name: str = "Home Assistant Integration",
+        description: str = None,
+        url: str = None,
+        data: str = None,
     ) -> str:
         """This methods allows an already provided token of an external system to be updated.
         The token is identified by the system name and the token identification."""
@@ -602,9 +603,9 @@ class Remote:
         raise ExternalSystemNotRegistered
 
     async def delete_token_for_external_system(
-            self,
-            system: str,
-            token_id: str,
+        self,
+        system: str,
+        token_id: str,
     ) -> str:
         """Deletes supplied token for the given system"""
 
@@ -686,56 +687,86 @@ class Remote:
 
     async def get_remote_drivers(self) -> list[dict[str, any]]:
         """List the integrations drivers on the remote."""
-        async with self.client() as session, session.get(
-                self.url("intg/drivers")) as response:
+        async with (
+            self.client() as session,
+            session.get(self.url("intg/drivers")) as response,
+        ):
             await self.raise_on_error(response)
             return await response.json()
 
     async def get_remote_integrations(self) -> list[dict[str, any]]:
         """List the integrations instances on the remote."""
-        async with self.client() as session, session.get(
-                self.url("intg/instances")) as response:
+        async with (
+            self.client() as session,
+            session.get(self.url("intg/instances")) as response,
+        ):
             await self.raise_on_error(response)
             return await response.json()
 
-    async def get_remote_integration_entities(self, integration_id, reload=False) -> list[dict[str, any]]:
+    async def get_remote_integration_entities(
+        self, integration_id, reload=False
+    ) -> list[dict[str, any]]:
         """Get the available entities of the given integration on the remote."""
-        async with self.client() as session, session.get(
-                self.url(f"intg/instances/{integration_id}/entities?reload=" +
-                         "true" if reload else "false")) as response:
+        async with (
+            self.client() as session,
+            session.get(
+                self.url(
+                    f"intg/instances/{integration_id}/entities?reload=" + "true"
+                    if reload
+                    else "false"
+                )
+            ) as response,
+        ):
             await self.raise_on_error(response)
             return await response.json()
 
-    async def set_remote_integration_entities(self, integration_id,
-                                              entity_ids: list[dict[str, any]]) -> bool:
+    async def set_remote_integration_entities(
+        self, integration_id, entity_ids: list[dict[str, any]]
+    ) -> bool:
         """Set the available entities of the given integration on the remote."""
-        async with self.client() as session, session.post(
-                self.url(f"intg/instances/{integration_id}/entities"),
-                json=entity_ids) as response:
+        async with (
+            self.client() as session,
+            session.post(
+                self.url(f"intg/instances/{integration_id}/entities"), json=entity_ids
+            ) as response,
+        ):
             await self.raise_on_error(response)
             return True
 
-    async def get_remote_subscribed_entities(self, integration_id: str) -> list[dict[str, any]]:
+    async def get_remote_subscribed_entities(
+        self, integration_id: str
+    ) -> list[dict[str, any]]:
         """Return the list of subscribed entities for the given integration id."""
-        async with self.client() as session, session.get(
-                self.url(f"entities?intg_ids={integration_id}")) as response:
+        async with (
+            self.client() as session,
+            session.get(self.url(f"entities?intg_ids={integration_id}")) as response,
+        ):
             await self.raise_on_error(response)
             return await response.json()
 
     async def add_remote_entities(self, integration_id, entity_ids: list[str]) -> bool:
         """Subscribe to the selected entities for the given integration id."""
         _LOGGER.debug("Add entities to remote %s : %s", self._ip_address, entity_ids)
-        async with self.client() as session, session.post(
-                self.url(f"/intg/instances/{integration_id}/entities"), json=entity_ids) as response:
+        async with (
+            self.client() as session,
+            session.post(
+                self.url(f"/intg/instances/{integration_id}/entities"), json=entity_ids
+            ) as response,
+        ):
             await self.raise_on_error(response)
             return True
 
     async def remove_remote_entities(self, entity_ids: list[str]) -> bool:
         """Remove the given subscribed entities."""
         _LOGGER.debug("Remove entities to remote %s : %s", self._ip_address, entity_ids)
-        async with self.client() as session, session.request(method="DELETE",
-                                                             url=self.url("/entities"),
-                                                             json={"entity_ids": entity_ids}) as response:
+        async with (
+            self.client() as session,
+            session.request(
+                method="DELETE",
+                url=self.url("/entities"),
+                json={"entity_ids": entity_ids},
+            ) as response,
+        ):
             await self.raise_on_error(response)
             return True
 
@@ -812,7 +843,7 @@ class Remote:
                 # _LOGGER.debug("get_activity_groups %s", json.dumps(activity_group_data, indent=2))
                 name = "DEFAULT"
                 if activity_group_data.get("name", None) and isinstance(
-                        activity_group_data.get("name", None), dict
+                    activity_group_data.get("name", None), dict
                 ):
                     name = next(iter(activity_group_data.get("name").values()))
                 activity_group = ActivityGroup(
@@ -857,15 +888,15 @@ class Remote:
             status = await response.json()
             self._memory_total = status.get("memory").get("total_memory") / 1048576
             self._memory_available = (
-                    status.get("memory").get("available_memory") / 1048576
+                status.get("memory").get("available_memory") / 1048576
             )
 
             self._storage_total = (
-                    status.get("filesystem").get("user_data").get("used")
-                    + status.get("filesystem").get("user_data").get("available") / 1048576
+                status.get("filesystem").get("user_data").get("used")
+                + status.get("filesystem").get("user_data").get("available") / 1048576
             )
             self._storage_available = (
-                    status.get("filesystem").get("user_data").get("available") / 1048576
+                status.get("filesystem").get("user_data").get("available") / 1048576
             )
 
             self._cpu_load = status.get("load_avg")
@@ -896,7 +927,7 @@ class Remote:
             return settings
 
     async def patch_remote_display_settings(
-            self, auto_brightness=None, brightness=None
+        self, auto_brightness=None, brightness=None
     ) -> bool:
         """Update remote display settings"""
         display_settings = await self.get_remote_display_settings()
@@ -926,7 +957,7 @@ class Remote:
             return settings
 
     async def patch_remote_button_settings(
-            self, auto_brightness=None, brightness=None
+        self, auto_brightness=None, brightness=None
     ) -> bool:
         """Update remote button settings"""
         button_settings = await self.get_remote_button_settings()
@@ -956,7 +987,7 @@ class Remote:
             return settings
 
     async def patch_remote_sound_settings(
-            self, sound_effects=None, sound_effects_volume=None
+        self, sound_effects=None, sound_effects_volume=None
     ) -> bool:
         """Update remote sound settings"""
         sound_settings = await self.get_remote_sound_settings()
@@ -1012,7 +1043,7 @@ class Remote:
             return settings
 
     async def patch_remote_power_saving_settings(
-            self, display_timeout=None, wakeup_sensitivity=None, sleep_timeout=None
+        self, display_timeout=None, wakeup_sensitivity=None, sleep_timeout=None
     ) -> bool:
         """Update remote power saving settings"""
         power_saving_settings = await self.get_remote_power_saving_settings()
@@ -1063,8 +1094,8 @@ class Remote:
                 for update in self._available_update:
                     if update.get("channel") in ["STABLE", "TESTING"]:
                         if (
-                                self._latest_sw_version == ""
-                                or self._latest_sw_version < update.get("version")
+                            self._latest_sw_version == ""
+                            or self._latest_sw_version < update.get("version")
                         ):
                             self._release_notes_url = update.get("release_notes_url")
                             self._latest_sw_version = update.get("version")
@@ -1100,8 +1131,8 @@ class Remote:
                 for update in self._available_update:
                     if update.get("channel") in ["STABLE", "TESTING"]:
                         if (
-                                self._latest_sw_version == ""
-                                or self._latest_sw_version < update.get("version")
+                            self._latest_sw_version == ""
+                            or self._latest_sw_version < update.get("version")
                         ):
                             self._release_notes_url = update.get("release_notes_url")
                             self._latest_sw_version = update.get("version")
@@ -1202,7 +1233,9 @@ class Remote:
             remotes = await response.json()
             for remote in remotes:
                 # integration_id == uc.main : bug with web configurator
-                if remote.get("enabled") is True and remote.get("integration_id").startswith("uc.main"):
+                if remote.get("enabled") is True and remote.get(
+                    "integration_id"
+                ).startswith("uc.main"):
                     remote_data = {
                         "name": remote.get("name").get("en"),
                         "entity_id": remote.get("entity_id"),
@@ -1267,7 +1300,7 @@ class Remote:
             return self._docks
 
     async def send_remote_command(
-            self, device="", command="", repeat=0, **kwargs
+        self, device="", command="", repeat=0, **kwargs
     ) -> bool:
         """Send a remote command to the dock kwargs: code,format,dock,port."""
         body_port = {}
@@ -1362,8 +1395,8 @@ class Remote:
                         case "PROGRESS":
                             step_offset = offset * (current_step - 1)
                             self._update_percent = (
-                                                           percentage_offset * progress.get("current_percent")
-                                                   ) + step_offset
+                                percentage_offset * progress.get("current_percent")
+                            ) + step_offset
                         case "SUCCESS":
                             self._update_percent = 100
                             self._sw_version = self.latest_sw_version
@@ -1420,8 +1453,8 @@ class Remote:
         try:
             # Extract media player entities for future use
             if (
-                    data["msg_data"]["entity_type"] == "media_player"
-                    and data["msg_data"]["new_state"]["attributes"]
+                data["msg_data"]["entity_type"] == "media_player"
+                and data["msg_data"]["new_state"]["attributes"]
             ):
                 attributes = data["msg_data"]["new_state"]["attributes"]
                 entity_id = data["msg_data"]["entity_id"]
@@ -1442,16 +1475,16 @@ class Remote:
             # TODO : not sure this will happen like that all the time :
             #  ["msg_data"]["new_state"]["attributes"]["step"]["command"] = { "cmd_id": "media_player.on", "entity_id": "<media player entity id>"...}
             if (
-                    data["msg_data"]["entity_type"] == "activity"
-                    and data["msg_data"]["new_state"]["attributes"]["state"] == "RUNNING"
-                    and data["msg_data"]["new_state"]["attributes"]["step"]["entity"][
-                "type"
-            ]
-                    == "media_player"
-                    and data["msg_data"]["new_state"]["attributes"]["step"]["command"][
-                "cmd_id"
-            ]
-                    == "media_player.on"
+                data["msg_data"]["entity_type"] == "activity"
+                and data["msg_data"]["new_state"]["attributes"]["state"] == "RUNNING"
+                and data["msg_data"]["new_state"]["attributes"]["step"]["entity"][
+                    "type"
+                ]
+                == "media_player"
+                and data["msg_data"]["new_state"]["attributes"]["step"]["command"][
+                    "cmd_id"
+                ]
+                == "media_player.on"
             ):
                 _LOGGER.debug(
                     "Unfolded circle remote update link between activity and entities"
@@ -1473,8 +1506,8 @@ class Remote:
         try:
             # Activity On or Off
             if data["msg_data"]["entity_type"] == "activity" and (
-                    data["msg_data"]["new_state"]["attributes"]["state"] == "ON"
-                    or data["msg_data"]["new_state"]["attributes"]["state"] == "OFF"
+                data["msg_data"]["new_state"]["attributes"]["state"] == "ON"
+                or data["msg_data"]["new_state"]["attributes"]["state"] == "OFF"
             ):
                 _LOGGER.debug("Unfolded circle remote update activity")
                 new_state = data["msg_data"]["new_state"]["attributes"]["state"]
@@ -1497,8 +1530,8 @@ class Remote:
                         group_state = "OFF"
                         for activity in self.activities:
                             if (
-                                    activity_group.is_activity_in_group(activity._id)
-                                    and activity.is_on()
+                                activity_group.is_activity_in_group(activity._id)
+                                and activity.is_on()
                             ):
                                 group_state = "ON"
                                 break
@@ -1743,7 +1776,7 @@ class UCMediaPlayerEntity:
             self._state = attributes.get("state", None)
             attributes_changed["state"] = self._state
             if (
-                    self._state is None or self._state == "OFF"
+                self._state is None or self._state == "OFF"
             ) and self.activity.state == "ON":
                 self._state = "ON"
         if attributes.get("media_image_url", None):

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -650,7 +650,8 @@ class Remote:
         """Get System wifi information from remote. address."""
         if self._is_simulator:
             self._mac_address = SIMULATOR_MAC_ADDRESS
-            self._ip_address = "192.168.1.26"
+            parsed_uri = urlparse(self.endpoint)
+            self._ip_address = parsed_uri.netloc
             return
         async with (
             self.client() as session,

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -459,7 +459,7 @@ class Remote:
         return response
 
     ### Unfolded Circle API Keys ###
-    async def get_api_keys(self) -> str:
+    async def get_api_keys(self) -> list[dict]:
         """Get all api Keys."""
         async with (
             self.client() as session,
@@ -629,7 +629,7 @@ class Remote:
                 return True
 
     @staticmethod
-    async def get_version_information(base_url) -> str:
+    async def get_version_information(base_url) -> dict[str]:
         """Get remote version information /pub/version"""
         headers = {
             "Accept": "application/json",

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -499,7 +499,7 @@ class Remote:
         ):
             await self.raise_on_error(response)
 
-    async def get_registered_external_systems(self) -> str:
+    async def get_registered_external_systems(self) -> dict:
         """Returns an array of dict[system,name] representing
         the registered external systems on the remote"""
         async with (
@@ -545,10 +545,13 @@ class Remote:
                 "token_id": f"{token_id}",
                 "name": f"{name}",
                 "token": f"{token}",
-                "description": f"{description}",
-                "url": f"{url}",
-                "data": f"{data}",
             }
+            if description:
+                body["description"] = description
+            if url:
+                body["url"] = url
+            if data:
+                body["data"] = data
             async with (
                 self.client() as session,
                 session.post(
@@ -600,7 +603,7 @@ class Remote:
             ):
                 await self.raise_on_error(response)
                 return await response.json()
-        raise ExternalSystemNotRegistered
+        raise ExternalSystemNotRegistered("Error while submitting the HA token to the remote")
 
     async def delete_token_for_external_system(
         self,

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -1525,7 +1525,7 @@ class Remote:
                 ]
                 == "media_player"
                 and data["msg_data"]["new_state"]["attributes"]["step"]["command"][
-                    "cmd_id"
+                "cmd_id"
                 ]
                 == "media_player.on"
             ):

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote_websocket.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote_websocket.py
@@ -124,14 +124,12 @@ class RemoteWebsocket:
         _LOGGER.debug(
             "UnfoldedCircleRemote subscribing to events %s", self.events_to_subscribe
         )
-        await self.send_message(
-            {
-                "id": 1,
-                "kind": "req",
-                "msg": "subscribe_events",
-                "msg_data": {"channels": self.events_to_subscribe},
-            }
-        )
+        await self.send_message({
+            "id": 1,
+            "kind": "req",
+            "msg": "subscribe_events",
+            "msg_data": {"channels": self.events_to_subscribe},
+        })
 
     async def send_message(self, message: any) -> None:
         """Send a message to the connected websocket."""

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/websocket.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/websocket.py
@@ -1,0 +1,95 @@
+"""Unfolded Circle Dock Web Socket Module"""
+
+import json
+import logging
+from typing import Callable, Coroutine
+from urllib.parse import urlparse
+from requests import Session
+from websockets import WebSocketClientProtocol
+
+from .const import AUTH_APIKEY_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LoggerAdapter(logging.LoggerAdapter):
+    """Logger class for websocket for debugging.
+    Add connection ID and client IP address to websockets logs."""
+
+    def process(self, msg, kwargs):
+        try:
+            websocket = kwargs["extra"]["websocket"]
+        except KeyError:
+            return msg, kwargs
+        return f"{websocket.id} {msg}", kwargs
+
+
+class Websocket:
+    """Web Socket Class for Unfolded Circle"""
+
+    session: Session | None
+    hostname: str
+    endpoint: str
+    api_key_name = AUTH_APIKEY_NAME
+    api_key: str = None
+    websocket: WebSocketClientProtocol | None = None
+
+    def __init__(
+        self, api_url: str, api_key: str = None, dock_password: str = None
+    ) -> None:
+        self.session = None
+        self.hostname = urlparse(api_url).hostname
+        self.api_key = api_key
+        self.websocket = None
+        self.dock_password = dock_password
+
+        if urlparse(api_url).scheme == "https":
+            self.protocol = "wss"
+        else:
+            self.protocol = "ws"
+
+        self.endpoint = api_url
+        self.api_endpoint = api_url
+        self.events_to_subscribe = [
+            "software_updates",
+        ]
+
+    async def init_websocket(
+        self,
+        receive_callback: Callable[..., Coroutine],
+        reconnection_callback: Callable[..., Coroutine],
+    ):
+        """init_websocket"""
+        pass
+
+    async def close_websocket(self):
+        """Terminate web socket connection"""
+        if self.websocket is not None:
+            await self.websocket.close(1001, "Close connection")  # 1001 : going away
+            self.websocket = None
+
+    async def subscribe_events(self) -> None:
+        """Subscribe to necessary events."""
+        _LOGGER.debug(
+            "UnfoldedCircle subscribing to events %s",
+            self.events_to_subscribe,
+        )
+        await self.send_message(
+            {
+                "id": 1,
+                "kind": "req",
+                "msg": "subscribe_events",
+                "msg_data": {"channels": self.events_to_subscribe},
+            }
+        )
+
+    async def send_message(self, message: any) -> None:
+        """Send a message to the connected websocket."""
+        try:
+            await self.websocket.send(json.dumps(message))
+        except Exception as ex:
+            _LOGGER.warning(
+                "UnfoldedCircle error while sending message %s",
+                ex,
+            )
+            raise ex

--- a/custom_components/unfoldedcircle/remote.py
+++ b/custom_components/unfoldedcircle/remote.py
@@ -1,16 +1,47 @@
 """Remote sensor platform for Unfolded Circle."""
 
+import asyncio
 from collections.abc import Iterable
+from datetime import timedelta
 from typing import Any, Mapping
+import logging
 
-from homeassistant.components.remote import RemoteEntity, RemoteEntityFeature
+import voluptuous as vol
+from homeassistant.util import dt as dt_util
+
+from homeassistant.components.remote import (
+    RemoteEntity,
+    RemoteEntityFeature,
+)
+from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import service, entity_platform
 from homeassistant.helpers.entity import ToggleEntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pyUnfoldedCircleRemote.remote import AuthenticationError
 
-from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
-from .entity import UnfoldedCircleEntity
+from .const import (
+    DOMAIN,
+    UNFOLDED_CIRCLE_COORDINATOR,
+    UNFOLDED_CIRCLE_DOCK_COORDINATORS,
+    LEARN_IR_COMMAND_SERVICE,
+)
+from .entity import UnfoldedCircleEntity, UnfoldedCircleDockEntity
+
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+LEARNING_TIMEOUT = timedelta(seconds=30)
+
+CREATE_CODESET_SCHEMA = cv.make_entity_service_schema(
+    {
+        vol.Required("remote"): dict,
+        vol.Required("ir_dataset"): dict,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup_entry(
@@ -20,28 +51,67 @@ async def async_setup_entry(
 ) -> None:
     """Set up Platform."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][UNFOLDED_CIRCLE_COORDINATOR]
+    dock_coordinators = hass.data[DOMAIN][config_entry.entry_id][
+        UNFOLDED_CIRCLE_DOCK_COORDINATORS
+    ]
+    platform = entity_platform.async_get_current_platform()
+
     async_add_entities([RemoteSensor(coordinator)])
 
+    for dock_coordinator in dock_coordinators:
+        async_add_entities([RemoteDockSensor(dock_coordinator)])
 
-class RemoteSensor(UnfoldedCircleEntity, RemoteEntity):
-    """Remote Sensor."""
+    @service.verify_domain_control(hass, DOMAIN)
+    async def async_service_handle(service_call: ServiceCall) -> None:
+        """Handle dispatched services."""
 
-    _attr_icon = "mdi:remote"
+        assert platform is not None
+        entities = await platform.async_extract_from_service(service_call)
+
+        if not entities:
+            return
+
+        for entity in entities:
+            assert isinstance(entity, RemoteDockSensor)
+
+        if service_call.service == LEARN_IR_COMMAND_SERVICE:
+            dock_coordinators = hass.data[DOMAIN][config_entry.entry_id][
+                UNFOLDED_CIRCLE_DOCK_COORDINATORS
+            ]
+
+            for coor in dock_coordinators:
+                coordinator = coor
+            ir = IR(coordinator, hass, data=service_call.data)
+            await ir.async_learn_command()
+
+    hass.services.async_register(
+        DOMAIN,
+        LEARN_IR_COMMAND_SERVICE,
+        async_service_handle,
+        CREATE_CODESET_SCHEMA,
+    )
+
+
+class RemoteDockSensor(UnfoldedCircleDockEntity, RemoteEntity):
+    """Dock Remote Sensor"""
+
     entity_description: ToggleEntityDescription
-    _attr_supported_features: RemoteEntityFeature = RemoteEntityFeature.ACTIVITY
+    _attr_supported_features: RemoteEntityFeature = (
+        RemoteEntityFeature.ACTIVITY
+        | RemoteEntityFeature.LEARN_COMMAND
+        | RemoteEntityFeature.DELETE_COMMAND
+    )
 
     def __init__(self, coordinator) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{self.coordinator.api.serial_number}_remote"
-        self._attr_name = f"{self.coordinator.api.name} Remote"
+        self._attr_unique_id = f"{self.coordinator.api.model_number}_{self.coordinator.api.serial_number}_remote"
+        self._attr_has_entity_name = True
+        self._attr_name = "Remote"
         self._attr_activity_list = []
         self._extra_state_attributes = {}
         self._attr_is_on = False
-
-        for activity in self.coordinator.api.activities:
-            self._attr_activity_list.append(activity.name)
-        # self.update_state()
+        self._attr_icon = "mdi:remote"
 
     @property
     def is_on(self) -> bool | None:
@@ -53,30 +123,15 @@ class RemoteSensor(UnfoldedCircleEntity, RemoteEntity):
 
     def update_state(self) -> bool:
         """Update current activity and extra state attributes"""
-        self._attr_is_on = False
-        self._attr_current_activity = None
-        for activity in self.coordinator.api.activities:
-            self._extra_state_attributes[activity.name] = activity.state
-            if activity.is_on():
-                self._attr_current_activity = activity.name
-                self._attr_is_on = True
-        for activity in self.coordinator.api.activities:
-            for entity in activity.mediaplayer_entities:
-                self._extra_state_attributes[entity.name] = entity.state
-
         return self._attr_is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        # Nothing can be done here
         self._attr_is_on = True
         return
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        for activity in self.coordinator.api.activities:
-            if activity.is_on():
-                await activity.turn_off()
         self._attr_is_on = False
 
     async def async_send_command(self, command: Iterable[str], **kwargs):
@@ -93,3 +148,178 @@ class RemoteSensor(UnfoldedCircleEntity, RemoteEntity):
         """Handle updated data from the coordinator."""
         self.update_state()
         self.async_write_ha_state()
+
+
+class RemoteSensor(UnfoldedCircleEntity, RemoteEntity):
+    """Remote Sensor."""
+
+    entity_description: ToggleEntityDescription
+    _attr_supported_features: RemoteEntityFeature = RemoteEntityFeature.ACTIVITY
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_remote"
+        self._attr_name = "Remote"
+        self._attr_activity_list = []
+        self._extra_state_attributes = {}
+        self._attr_is_on = False
+        self._attr_icon = "mdi:remote"
+
+        if hasattr(self.coordinator.api, "activities"):
+            for activity in self.coordinator.api.activities:
+                self._attr_activity_list.append(activity.name)
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._attr_is_on
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        return self._extra_state_attributes
+
+    def update_state(self) -> bool:
+        """Update current activity and extra state attributes"""
+        # self._attr_is_on = False
+        self._attr_current_activity = None
+        if hasattr(self.coordinator.api, "activities"):
+            for activity in self.coordinator.api.activities:
+                self._extra_state_attributes[activity.name] = activity.state
+                if activity.is_on():
+                    self._attr_current_activity = activity.name
+                    self._attr_is_on = True
+            for activity in self.coordinator.api.activities:
+                for entity in activity.mediaplayer_entities:
+                    self._extra_state_attributes[entity.name] = entity.state
+
+        return self._attr_is_on
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        # Nothing can be done here
+        self._attr_is_on = True
+        return
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        if hasattr(self.coordinator.api, "activities"):
+            for activity in self.coordinator.api.activities:
+                if activity.is_on():
+                    await activity.turn_off()
+        self._attr_is_on = False
+
+    async def async_send_command(self, command: Iterable[str], **kwargs):
+        """Send a remote command."""
+        for indv_command in command:
+            await self.coordinator.api.send_remote_command(
+                device=kwargs.get("device"),
+                command=indv_command,
+                repeat=kwargs.get("num_repeats"),
+            )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.update_state()
+        self.async_write_ha_state()
+
+
+class IR:
+    def __init__(self, coordinator, hass, data):
+        self.coordinator = coordinator
+        self.hass = hass
+        self.data = data
+
+    async def async_learn_command(self, **kwargs: Any) -> None:
+        """Learn a list of commands from a remote."""
+
+        await self.coordinator.api.get_remotes_complete()
+
+        name = self.data.get("remote").get("name")
+        description = self.data.get("remote").get("description")
+        icon = self.data.get("remote").get("icon")
+        subdevice = self.data.get("ir_dataset").get("name")
+        for command in self.data.get("ir_dataset").get("command"):
+            try:
+                code = await self._async_learn_ir_command(
+                    command, subdevice, name, description, icon
+                )
+
+            except (AuthenticationError, OSError) as err:
+                _LOGGER.error("Failed to learn '%s': %s", command, err)
+                break
+
+            except Exception as err:
+                _LOGGER.error("Failed to learn '%s': %s", command, err)
+                continue
+
+    async def _async_learn_ir_command(self, command, device, name, description, icon):
+        """Learn an infrared command."""
+
+        try:
+            await self.coordinator.api.start_ir_learning()
+
+        except (Exception, OSError) as err:
+            _LOGGER.debug("Failed to enter learning mode: %s", err)
+            raise
+
+        persistent_notification.async_create(
+            self.hass,
+            f"Press the '{command}' button.",
+            title=f"Learn command for {device}",
+            notification_id="learn_command",
+        )
+
+        is_existing_list = False
+        remote_entity_id = ""
+        for remote in self.coordinator.api.remotes_complete:
+            if remote.get("options").get("ir").get("codeset").get("name") == device:
+                remote_entity_id = remote.get("entity_id")
+                is_existing_list = True
+
+        if not is_existing_list:
+            try:
+                new_remote = await self.coordinator.api.create_remote(
+                    name=name,
+                    device=device,
+                    description=description,
+                    icon=icon,
+                )
+                remote_entity_id = new_remote.get("entity_id")
+                # Refresh the list of remotes (We are shortcutting to save time. This
+                # probably should just call the get_remotes_complete() method)
+                await self.coordinator.api._remotes_complete.append(new_remote.copy())
+            except Exception as ex:
+                pass
+
+        try:
+            start_time = dt_util.utcnow()
+            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
+                await asyncio.sleep(1)
+                try:
+                    if self.coordinator.api.learned_code:
+                        ir_format = "HEX"
+                        learned_code: str = self.coordinator.api.learned_code
+                        if "0x" not in learned_code.lower():
+                            ir_format = "PRONTO"
+
+                        await self.coordinator.api.add_remote_command_to_codeset(
+                            remote_entity_id,
+                            command,
+                            learned_code,
+                            ir_format,
+                        )
+                        self.coordinator.api._learned_code = None
+                        return self.coordinator.api._learned_code
+                except AuthenticationError:
+                    continue
+
+            raise TimeoutError(
+                f"No infrared code received within {LEARNING_TIMEOUT.total_seconds()} seconds"
+            )
+
+        finally:
+            persistent_notification.async_dismiss(
+                self.hass, notification_id="learn_command"
+            )

--- a/custom_components/unfoldedcircle/repairs.py
+++ b/custom_components/unfoldedcircle/repairs.py
@@ -1,0 +1,98 @@
+"""Unfolded Circle Repairs"""
+
+from __future__ import annotations
+import logging
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.helpers import issue_registry
+from homeassistant.core import HomeAssistant
+from .helpers import validate_dock_password
+from .config_flow import CannotConnect, InvalidDockPassword
+from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class DockPasswordRepairFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    def __init__(self, hass, issue_id, data) -> None:
+        super().__init__()
+        self.data = data
+        self.issue_id = issue_id
+        self.hass = hass
+        self.coordinator = self.hass.data[DOMAIN][self.data.get("config_entry_id")][
+            UNFOLDED_CIRCLE_COORDINATOR
+        ]
+        self.config_entry = self.coordinator.config_entry
+        self.dock_total = 0
+        self.dock_count = 0
+
+        for dock in self.config_entry.data["docks"]:
+            if dock["password"] == "":
+                self.dock_total += 1
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, str] | None = None,
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                self.data["password"] = user_input.get("password")
+                coordinator = self.hass.data[DOMAIN][self.data.get("config_entry_id")][
+                    UNFOLDED_CIRCLE_COORDINATOR
+                ]
+                existing_entry = coordinator.config_entry
+                is_valid = await validate_dock_password(coordinator.api, self.data)
+                if is_valid:
+                    config_data = existing_entry
+                    for info in config_data.data["docks"]:
+                        if info.get("id") == self.data.get("id"):
+                            info["password"] = self.data["password"]
+                    self.hass.config_entries.async_update_entry(
+                        existing_entry, data=config_data.data
+                    )
+
+                    await self.hass.config_entries.async_reload(existing_entry.entry_id)
+
+                    issue_registry.async_delete_issue(self.hass, DOMAIN, self.issue_id)
+
+                    return self.async_abort(reason="reauth_successful")
+                else:
+                    raise InvalidDockPassword
+
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidDockPassword:
+                errors["base"] = "invalid_dock_password"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="confirm",
+            errors=errors,
+            data_schema=vol.Schema({vol.Required("password"): str}),
+            description_placeholders={"name": self.data["name"]},
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if issue_id.startswith("dock_password"):
+        return DockPasswordRepairFlow(hass, issue_id, data)

--- a/custom_components/unfoldedcircle/select.py
+++ b/custom_components/unfoldedcircle/select.py
@@ -9,7 +9,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
-from .const import CONF_SUPPRESS_ACTIVITIY_GROUPS, DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+from .const import (
+    CONF_SUPPRESS_ACTIVITIY_GROUPS,
+    DOMAIN,
+    UNFOLDED_CIRCLE_COORDINATOR,
+)
 from .entity import UnfoldedCircleEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,10 +43,9 @@ class SelectUCRemoteActivity(UnfoldedCircleEntity, SelectEntity):
         """Initialize a switch."""
         super().__init__(coordinator)
         self.activity_group = activity_group
-        self._attr_name = f"{self.coordinator.api.name} {activity_group.name}"
-        self._attr_unique_id = (
-            f"{self.coordinator.api.serial_number}_{activity_group._id}"
-        )
+        self._attr_has_entity_name = True
+        self._attr_name = f"{activity_group.name}"
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_{activity_group._id}"
         self._state = activity_group.state
         self._attr_icon = "mdi:remote-tv"
         self._attr_native_value = "OFF"

--- a/custom_components/unfoldedcircle/select.py
+++ b/custom_components/unfoldedcircle/select.py
@@ -7,7 +7,7 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import CONF_SUPPRESS_ACTIVITIY_GROUPS, DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
 from .entity import UnfoldedCircleEntity

--- a/custom_components/unfoldedcircle/sensor.py
+++ b/custom_components/unfoldedcircle/sensor.py
@@ -7,11 +7,19 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfInformation
+from homeassistant.const import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfInformation,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+from .const import (
+    DOMAIN,
+    UNFOLDED_CIRCLE_COORDINATOR,
+)
 from .entity import UnfoldedCircleEntity
 
 
@@ -106,14 +114,15 @@ class UnfoldedCircleSensor(UnfoldedCircleEntity, SensorEntity):
     entity_description = UNFOLDED_CIRCLE_SENSOR
 
     def __init__(
-        self, coordinator, description: UnfoldedCircleSensorEntityDescription
+        self,
+        coordinator,
+        description: UnfoldedCircleSensorEntityDescription,
     ) -> None:
         """Initialize Unfolded Circle Sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self.coordinator.api.serial_number}_{description.unique_id}"
-        )
-        self._attr_name = f"{self.coordinator.api.name} {description.name}"
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_{description.unique_id}"
+        self._attr_has_entity_name = True
+        self._attr_name = f"{description.name}"
         self._attr_unit_of_measurement = description.unit_of_measurement
         self._attr_native_unit_of_measurement = description.unit_of_measurement
         self._device_class = description.device_class

--- a/custom_components/unfoldedcircle/services.yaml
+++ b/custom_components/unfoldedcircle/services.yaml
@@ -12,3 +12,20 @@ update_activity:
       required: false
       selector:
         boolean:
+
+learn_ir_command:
+  name: Learn IR Commands
+  description: Allows for the automated learning of a sequence of IR commands
+  target:
+    entity:
+      - integration: unfoldedcircle
+        domain: remote
+  fields:
+    remote:
+      name: Remote Entity Information
+      description: Remote Dictionary containing -> Name, Description, and Icon
+      required: true
+    ir_dataset:
+      name: IR Codeset Information
+      description: IR Codeset Dictionary containing -> Name and a list of commands
+      required: true

--- a/custom_components/unfoldedcircle/strings.json
+++ b/custom_components/unfoldedcircle/strings.json
@@ -7,6 +7,12 @@
           "host": "[%key:common::config_flow::data::host%]"
         }
       },
+      "dock": {
+        "title": "Docks",
+        "data": {
+          "password": "{name} Password"
+        }
+      },
       "zeroconf_confirm": {
         "data": {
           "pin": "[%key:common::config_flow::data::pin%]"

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import (
     CONF_ACTIVITIES_AS_SWITCHES,

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -15,7 +15,6 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import (
     CONF_ACTIVITIES_AS_SWITCHES,
@@ -25,6 +24,7 @@ from .const import (
 )
 from .coordinator import UnfoldedCircleRemoteCoordinator
 from .entity import UnfoldedCircleEntity
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 
 @dataclass

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -157,9 +157,9 @@ async def async_setup_entry(
             )
             test = 1 + 1
 
-    prevent_sleep_schema = cv.make_entity_service_schema(
-        {vol.Optional(ATTR_PREVENT_SLEEP, default=False): cv.boolean}
-    )
+    prevent_sleep_schema = cv.make_entity_service_schema({
+        vol.Optional(ATTR_PREVENT_SLEEP, default=False): cv.boolean
+    })
 
     hass.services.async_register(
         DOMAIN, UPDATE_ACTIVITY_SERVICE, async_service_handle, prevent_sleep_schema

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -162,7 +162,10 @@ async def async_setup_entry(
     })
 
     hass.services.async_register(
-        DOMAIN, UPDATE_ACTIVITY_SERVICE, async_service_handle, prevent_sleep_schema
+        DOMAIN,
+        UPDATE_ACTIVITY_SERVICE,
+        async_service_handle,
+        prevent_sleep_schema,
     )
 
 
@@ -173,7 +176,8 @@ class UCRemoteSwitch(UnfoldedCircleEntity, SwitchEntity):
         """Initialize a switch."""
         super().__init__(coordinator)
         self.switch = switch
-        self._attr_name = f"{self.coordinator.api.name} {switch.name}"
+        self._attr_has_entity_name = True
+        self._attr_name = switch.name
         self._attr_unique_id = switch._id
         self._state = switch.state
         self._attr_icon = "mdi:remote-tv"
@@ -226,10 +230,9 @@ class UCRemoteConfigSwitch(UnfoldedCircleEntity, SwitchEntity):
         self._description = description
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = (
-            f"{self.coordinator.api.serial_number}_{description.unique_id}"
-        )
-        self._attr_name = f"{self.coordinator.api.name} {description.name}"
+        self._attr_unique_id = f"{coordinator.api.model_number}_{self.coordinator.api.serial_number}_{description.unique_id}"
+        self._attr_has_entity_name = True
+        self._attr_name = f"{description.name}"
         key = "_" + self._description.key
         self._attr_native_value = coordinator.data.get(key)
         if coordinator.data.get(key) is True:

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -37,7 +37,7 @@
           "remove_entities": "Remove entities"
         },
         "menu_options": {
-          "select_entities": "Retry connection",
+          "select_entities": "Remote is not connected, retry",
           "finish": "Ignore this step and finish"
         }
       }
@@ -48,9 +48,9 @@
       "init": {
         "title": "Unfolded Circle Options",
         "description": "Configure the remote entities or the component",
-        "data": {
-          "configuration_mode": "Configuration mode",
-          "advanced_configuration": "Advanced configuration"
+        "menu_options": {
+          "select_entities": "Configure the entities on the remote",
+          "activities": "Configure the integration"
         }
       },
       "media_player": {
@@ -68,13 +68,6 @@
         "data": {
           "activities_as_switches": "Create all activities as switch entities",
           "suppress_activity_groups": "Suppress creation of activity group entities"
-        }
-      },
-      "select_integration": {
-        "title": "Unfolded Circle Options",
-        "description": "Select the targeted Home Assistant integration",
-        "data": {
-          "integration": "Home Assistant Integration"
         }
       },
       "select_entities": {

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -28,17 +28,29 @@
           "pin": "PIN Code"
         },
         "title": "Reauthenticate with PIN"
+      },
+      "select_entities": {
+        "title": "Unfolded Circle Options",
+        "description": "Add or remove entities to the remote",
+        "data": {
+          "add_entities": "Add entities",
+          "remove_entities": "Remove entities"
+        },
+        "menu_options": {
+          "select_entities": "Retry connection",
+          "finish": "Ignore this step and finish"
+        }
       }
     }
   },
   "options": {
     "step": {
       "init": {
+        "title": "Unfolded Circle Options",
+        "description": "Configure the remote entities or the component",
         "data": {
-          "host": "Host",
-          "pin": "PIN Code",
-          "add_entities": "Add entities",
-          "remove_entities": "Remove entities"
+          "configuration_mode": "Configuration mode",
+          "advanced_configuration": "Advanced configuration"
         }
       },
       "media_player": {
@@ -56,6 +68,21 @@
         "data": {
           "activities_as_switches": "Create all activities as switch entities",
           "suppress_activity_groups": "Suppress creation of activity group entities"
+        }
+      },
+      "select_integration": {
+        "title": "Unfolded Circle Options",
+        "description": "Select the targeted Home Assistant integration",
+        "data": {
+          "integration": "Home Assistant Integration"
+        }
+      },
+      "select_entities": {
+        "title": "Unfolded Circle Options",
+        "description": "Add or remove entities to the remote",
+        "data": {
+          "add_entities": "Add entities",
+          "remove_entities": "Remove entities"
         }
       }
     }

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -3,11 +3,13 @@
     "abort": {
       "already_configured": "Device is already configured",
       "already_in_progress": "Device is pending setup",
-      "no_mac": "This device is not recognized as a valid Unfolded Circle Remote (No MAC Address)"
+      "no_mac": "This device is not recognized as a valid Unfolded Circle Remote (No MAC Address)",
+      "reauth_successful": "Reauthentication was successful"
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
+      "invalid_dock_password": "Incorrect dock password. Submit with an empty password to skip",
+      "invalid_auth": "Incorrect pin supplied. Please try again",
       "unknown": "Unexpected error"
     },
     "step": {
@@ -15,6 +17,13 @@
         "data": {
           "host": "Host",
           "pin": "PIN Code"
+        }
+      },
+      "dock": {
+        "title": "Supply {name} Password {count}",
+        "description": "If you don't remember your password, just submit. To finish dock setup, go to Settings and complete the Repair",
+        "data": {
+          "password": "Password"
         }
       },
       "zeroconf_confirm": {
@@ -76,6 +85,31 @@
         "data": {
           "add_entities": "Add entities",
           "remove_entities": "Remove entities"
+        }
+      }
+    }
+  },
+  "issues": {
+    "dock_password": {
+      "title": "Supply {name} Password",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Supply {name} Password",
+            "description": "Your dock password is needed to offer learning support",
+            "data": {
+              "password": "{name} Password"
+            }
+          }
+        },
+        "error": {
+          "cannot_connect": "Failed to connect",
+          "invalid_dock_password": "Incorrect dock password. Please try again",
+          "invalid_auth": "Incorrect pin supplied. Please try again",
+          "unknown": "Unexpected error"
+        },
+        "abort": {
+          "reauth_successful": "Dock authentication was successful"
         }
       }
     }

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -36,7 +36,9 @@
       "init": {
         "data": {
           "host": "Host",
-          "pin": "PIN Code"
+          "pin": "PIN Code",
+          "add_entities": "Add entities",
+          "remove_entities": "Remove entities"
         }
       },
       "media_player": {

--- a/custom_components/unfoldedcircle/update.py
+++ b/custom_components/unfoldedcircle/update.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.remote import HTTPError
+from .pyUnfoldedCircleRemote.remote import HTTPError
 
 from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
 from .entity import UnfoldedCircleEntity

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -1,5 +1,5 @@
 """Custom websocket commands --
-    Implements the necessary methods called through HA websocket for the UC HA integration."""
+Implements the necessary methods called through HA websocket for the UC HA integration."""
 
 import logging
 from dataclasses import dataclass
@@ -46,24 +46,20 @@ def ws_get_info(
     """Handle get info command."""
     # websocket_client = UCWebsocketClient(hass)
     _LOGGER.debug("Unfolded Circle connect request %s", msg)
-    connection.send_message(
-        {
-            "id": msg.get("id"),
-            "type": "result",
-            "success": True,
-            "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
-            "message": msg.get("message"),
-            "data": msg.get("data"),
-        }
-    )
+    connection.send_message({
+        "id": msg.get("id"),
+        "type": "result",
+        "success": True,
+        "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
+        "message": msg.get("message"),
+        "data": msg.get("data"),
+    })
 
 
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): f"{DOMAIN}/event/configure/subscribe",
-        vol.Optional("data"): dict[any, any],
-    }
-)
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{DOMAIN}/event/configure/subscribe",
+    vol.Optional("data"): dict[any, any],
+})
 @callback
 def ws_configure_event(
     hass: HomeAssistant,
@@ -76,12 +72,10 @@ def ws_configure_event(
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): f"{DOMAIN}/event/configure/unsubscribe",
-        vol.Optional("data"): dict[any, any],
-    }
-)
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{DOMAIN}/event/configure/unsubscribe",
+    vol.Optional("data"): dict[any, any],
+})
 @callback
 def ws_configure_unsubscribe_event(
     hass: HomeAssistant,
@@ -95,12 +89,10 @@ def ws_configure_unsubscribe_event(
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): f"{DOMAIN}/event/entities/unsubscribe",
-        vol.Optional("data"): dict[any, any],
-    }
-)
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{DOMAIN}/event/entities/unsubscribe",
+    vol.Optional("data"): dict[any, any],
+})
 @callback
 def ws_unsubscribe_entities_event(
     hass: HomeAssistant,
@@ -115,12 +107,10 @@ def ws_unsubscribe_entities_event(
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command(
-    {
-        vol.Required("type"): f"{DOMAIN}/event/entities/subscribe",
-        vol.Optional("data"): dict[any, any],
-    }
-)
+@websocket_api.websocket_command({
+    vol.Required("type"): f"{DOMAIN}/event/entities/subscribe",
+    vol.Optional("data"): dict[any, any],
+})
 @callback
 def ws_subscribe_entities_event(
     hass: HomeAssistant,
@@ -251,15 +241,13 @@ class UCWebsocketClient(metaclass=Singleton):
             old_state = event.data["old_state"]
             new_state = event.data["new_state"]
             _LOGGER.debug("Received notification to send to UC remote %s", event)
-            subscription.notification_callback(
-                {
-                    "data": {
-                        "entity_id": entity_id,
-                        "new_state": new_state,
-                        "old_state": old_state,  # TODO : old state useful ?
-                    }
+            subscription.notification_callback({
+                "data": {
+                    "entity_id": entity_id,
+                    "new_state": new_state,
+                    "old_state": old_state,  # TODO : old state useful ?
                 }
-            )
+            })
 
         def remove_listener() -> None:
             """Remove the listener."""

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -115,9 +115,10 @@ def ws_configure_unsubscribe_event(
     msg: dict,
 ) -> None:
     """Subscribe event to push modifications of configuration to the remote."""
-    cancel_callback = connection.subscriptions.get(msg.get("data", {})
-                                                   .get("subscription_id", ""), None)
+    subscription_id = msg.get("data", {}).get("subscription_id", "")
+    cancel_callback = connection.subscriptions.get(subscription_id, None)
     if cancel_callback is not None:
+        _LOGGER.debug(f"Unsubscribe {DOMAIN}/event/configure/unsubscribe for id %s", subscription_id)
         cancel_callback()
     connection.send_result(msg["id"])
 
@@ -133,9 +134,10 @@ def ws_unsubscribe_entities_event(
     msg: dict,
 ) -> None:
     """Unsubscribe events."""
-    cancel_callback = connection.subscriptions.get(msg.get("data", {})
-                                                   .get("subscription_id", ""), None)
+    subscription_id = msg.get("data", {}).get("subscription_id", "")
+    cancel_callback = connection.subscriptions.get(subscription_id, None)
     if cancel_callback is not None:
+        _LOGGER.debug(f"Unsubscribe {DOMAIN}/event/entities/unsubscribe for id %s", subscription_id)
         cancel_callback()
     connection.send_result(msg["id"])
 

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -73,7 +73,7 @@ def ws_get_states(
     entity_states = []
     # If entity_ids list is empty, send all entities
     if len(entity_ids) == 0:
-        entity_states = hass.states.all()
+        entity_states = hass.states.async_all()
     else:
         for entity_id in entity_ids:
             state = hass.states.get(entity_id)
@@ -115,7 +115,8 @@ def ws_configure_unsubscribe_event(
     msg: dict,
 ) -> None:
     """Subscribe event to push modifications of configuration to the remote."""
-    cancel_callback = connection.subscriptions.get(msg["id"], None)
+    cancel_callback = connection.subscriptions.get(msg.get("data", {})
+                                                   .get("subscription_id", ""), None)
     if cancel_callback is not None:
         cancel_callback()
     connection.send_result(msg["id"])
@@ -132,8 +133,8 @@ def ws_unsubscribe_entities_event(
     msg: dict,
 ) -> None:
     """Unsubscribe events."""
-    # websocket_client = UCWebsocketClient(hass)
-    cancel_callback = connection.subscriptions.get(msg["id"], None)
+    cancel_callback = connection.subscriptions.get(msg.get("data", {})
+                                                   .get("subscription_id", ""), None)
     if cancel_callback is not None:
         cancel_callback()
     connection.send_result(msg["id"])

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
 )
 
-from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ STATES_SCHEMA = {
     vol.Optional("message", description="Any String"): str,
     vol.Optional("data", description="Any Dict"): dict[any, any],
 }
+
 
 @dataclass
 class SubscriptionEvent:
@@ -50,14 +51,16 @@ def ws_get_info(
 ) -> None:
     """Handle get info command."""
     _LOGGER.debug("Unfolded Circle connect request %s", msg)
-    connection.send_message({
-        "id": msg.get("id"),
-        "type": "result",
-        "success": True,
-        "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
-        "message": msg.get("message"),
-        "data": msg.get("data"),
-    })
+    connection.send_message(
+        {
+            "id": msg.get("id"),
+            "type": "result",
+            "success": True,
+            "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
+            "message": msg.get("message"),
+            "data": msg.get("data"),
+        }
+    )
 
 
 @websocket_api.websocket_command(STATES_SCHEMA)
@@ -80,18 +83,22 @@ def ws_get_states(
             if state is not None:
                 entity_states.append(state)
     # Send requested entity states back to remote
-    connection.send_message({
-        "id": msg.get("id"),
-        "type": "result",
-        "success": True,
-        "result": entity_states,
-    })
+    connection.send_message(
+        {
+            "id": msg.get("id"),
+            "type": "result",
+            "success": True,
+            "result": entity_states,
+        }
+    )
 
 
-@websocket_api.websocket_command({
-    vol.Required("type"): f"{DOMAIN}/event/configure/subscribe",
-    vol.Optional("data"): dict[any, any],
-})
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/configure/subscribe",
+        vol.Optional("data"): dict[any, any],
+    }
+)
 @callback
 def ws_configure_event(
     hass: HomeAssistant,
@@ -104,10 +111,12 @@ def ws_configure_event(
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command({
-    vol.Required("type"): f"{DOMAIN}/event/configure/unsubscribe",
-    vol.Optional("data"): dict[any, any],
-})
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/configure/unsubscribe",
+        vol.Optional("data"): dict[any, any],
+    }
+)
 @callback
 def ws_configure_unsubscribe_event(
     hass: HomeAssistant,
@@ -118,15 +127,20 @@ def ws_configure_unsubscribe_event(
     subscription_id = msg.get("data", {}).get("subscription_id", "")
     cancel_callback = connection.subscriptions.get(subscription_id, None)
     if cancel_callback is not None:
-        _LOGGER.debug(f"Unsubscribe {DOMAIN}/event/configure/unsubscribe for id %s", subscription_id)
+        _LOGGER.debug(
+            f"Unsubscribe {DOMAIN}/event/configure/unsubscribe for id %s",
+            subscription_id,
+        )
         cancel_callback()
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command({
-    vol.Required("type"): f"{DOMAIN}/event/entities/unsubscribe",
-    vol.Optional("data"): dict[any, any],
-})
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/entities/unsubscribe",
+        vol.Optional("data"): dict[any, any],
+    }
+)
 @callback
 def ws_unsubscribe_entities_event(
     hass: HomeAssistant,
@@ -137,15 +151,20 @@ def ws_unsubscribe_entities_event(
     subscription_id = msg.get("data", {}).get("subscription_id", "")
     cancel_callback = connection.subscriptions.get(subscription_id, None)
     if cancel_callback is not None:
-        _LOGGER.debug(f"Unsubscribe {DOMAIN}/event/entities/unsubscribe for id %s", subscription_id)
+        _LOGGER.debug(
+            f"Unsubscribe {DOMAIN}/event/entities/unsubscribe for id %s",
+            subscription_id,
+        )
         cancel_callback()
     connection.send_result(msg["id"])
 
 
-@websocket_api.websocket_command({
-    vol.Required("type"): f"{DOMAIN}/event/entities/subscribe",
-    vol.Optional("data"): dict[any, any],
-})
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/entities/subscribe",
+        vol.Optional("data"): dict[any, any],
+    }
+)
 @callback
 def ws_subscribe_entities_event(
     hass: HomeAssistant,
@@ -277,13 +296,15 @@ class UCWebsocketClient(metaclass=Singleton):
             old_state = event.data["old_state"]
             new_state = event.data["new_state"]
             _LOGGER.debug("Received notification to send to UC remote %s", event)
-            subscription.notification_callback({
-                "data": {
-                    "entity_id": entity_id,
-                    "new_state": new_state,
-                    "old_state": old_state,  # TODO : old state useful ?
+            subscription.notification_callback(
+                {
+                    "data": {
+                        "entity_id": entity_id,
+                        "new_state": new_state,
+                        "old_state": old_state,  # TODO : old state useful ?
+                    }
                 }
-            })
+            )
 
         def remove_listener() -> None:
             """Remove the listener."""

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -1,0 +1,119 @@
+"""Custom websocket commands --
+    Implements the necessary methods called through HA websocket for the UC HA integration."""
+
+import logging
+
+import voluptuous as vol
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
+
+_LOGGER = logging.getLogger(__name__)
+
+INFO_SCHEMA = {
+    vol.Required("type"): f"{DOMAIN}/info",
+    vol.Optional("message", description="Any String"): str,
+    vol.Optional("data", description="Any Dict"): dict[any, any],
+}
+
+
+class UCClientInterface:
+    """Unfolded Circle interface to handle remote requests"""
+
+    def subscribe_entities_events(
+        self, connection: websocket_api.ActiveConnection, msg: dict
+    ) -> None:
+        """Method called by the HA websocket component
+        when a remote requests to subscribe to entity events."""
+
+
+@callback
+def async_register_websocket_commands(hass: HomeAssistant) -> None:
+    """Register network websocket commands."""
+    websocket_api.async_register_command(hass, ws_get_info)
+    websocket_api.async_register_command(
+        hass,
+        ws_subscribe_event,
+    )
+    websocket_api.async_register_command(hass, ws_unsubscribe_event)
+
+
+@websocket_api.websocket_command(INFO_SCHEMA)
+@callback
+def ws_get_info(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Handle get info command."""
+
+    _LOGGER.debug("Unfolded Circle connect request %s", msg)
+    connection.send_message(
+        {
+            "id": msg.get("id"),
+            "type": "result",
+            "success": True,
+            "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
+            "message": msg.get("message"),
+            "data": msg.get("data"),
+        }
+    )
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/unsubscribe",
+    }
+)
+@callback
+def ws_unsubscribe_event(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Subscribe to incoming and outgoing events."""
+    if hass.data[DOMAIN] is None:
+        _LOGGER.error("Unfolded Circle integration not configured")
+        connection.send_result(msg["id"])
+        return
+
+    coordinator: UCClientInterface = (next(iter(hass.data[DOMAIN].values()))).get(
+        UNFOLDED_CIRCLE_COORDINATOR, None
+    )
+    if coordinator is None:
+        _LOGGER.error("Unfolded Circle coordinator not initialized")
+        connection.send_result(msg["id"])
+        return
+
+    cancel_callback = connection.subscriptions.get(msg["id"], None)
+    if cancel_callback is not None:
+        cancel_callback()
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/event/subscribed_entities",
+        vol.Optional("data"): dict[any, any],
+    }
+)
+@callback
+def ws_subscribe_event(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Subscribe to incoming and outgoing events."""
+    if hass.data[DOMAIN] is None:
+        _LOGGER.error("Unfolded Circle integration not configured")
+        return
+
+    coordinator: UCClientInterface = (next(iter(hass.data[DOMAIN].values()))).get(
+        UNFOLDED_CIRCLE_COORDINATOR, None
+    )
+    if coordinator is None:
+        _LOGGER.error("Unfolded Circle coordinator not initialized")
+
+    coordinator.subscribe_entities_events(connection, msg)
+    connection.send_result(msg["id"])

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -2,11 +2,16 @@
     Implements the necessary methods called through HA websocket for the UC HA integration."""
 
 import logging
+from dataclasses import dataclass
+from typing import Callable, Any
 
 import voluptuous as vol
 from homeassistant.components import websocket_api
-from homeassistant.core import HomeAssistant, callback
-
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
 from .const import DOMAIN, UNFOLDED_CIRCLE_COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,36 +23,26 @@ INFO_SCHEMA = {
 }
 
 
-class UCClientInterface:
-    """Unfolded Circle interface to handle remote requests"""
+@dataclass
+class SubscriptionEvent:
+    """Subcription Event Data Class"""
 
-    def subscribe_entities_events(
-        self, connection: websocket_api.ActiveConnection, msg: dict
-    ) -> None:
-        """Method called by the HA websocket component
-        when a remote requests to subscribe to entity events."""
-
-
-@callback
-def async_register_websocket_commands(hass: HomeAssistant) -> None:
-    """Register network websocket commands."""
-    websocket_api.async_register_command(hass, ws_get_info)
-    websocket_api.async_register_command(
-        hass,
-        ws_subscribe_event,
-    )
-    websocket_api.async_register_command(hass, ws_unsubscribe_event)
+    client_id: str
+    subscription_id: int
+    cancel_subscription_callback: Callable
+    notification_callback: Callable[[dict[any, any]], None]
+    entity_ids: list[str] | None
 
 
 @websocket_api.websocket_command(INFO_SCHEMA)
 @callback
 def ws_get_info(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict,
 ) -> None:
     """Handle get info command."""
-
+    # websocket_client = UCWebsocketClient(hass)
     _LOGGER.debug("Unfolded Circle connect request %s", msg)
     connection.send_message(
         {
@@ -63,29 +58,36 @@ def ws_get_info(
 
 @websocket_api.websocket_command(
     {
+        vol.Required("type"): f"{DOMAIN}/event/configure",
+        vol.Optional("data"): dict[any, any],
+    }
+)
+@callback
+def ws_configure_event(
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict,
+) -> None:
+    """Subscribe event to push modifications of configuration to the remote."""
+    websocket_client = UCWebsocketClient(hass)
+    websocket_client.subscribe_entities_events(connection, msg)
+    connection.send_result(msg["id"])
+
+
+@websocket_api.websocket_command(
+    {
         vol.Required("type"): f"{DOMAIN}/event/unsubscribe",
+        vol.Optional("data"): dict[any, any],
     }
 )
 @callback
 def ws_unsubscribe_event(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict,
 ) -> None:
-    """Subscribe to incoming and outgoing events."""
-    if hass.data[DOMAIN] is None:
-        _LOGGER.error("Unfolded Circle integration not configured")
-        connection.send_result(msg["id"])
-        return
-
-    coordinator: UCClientInterface = (next(iter(hass.data[DOMAIN].values()))).get(
-        UNFOLDED_CIRCLE_COORDINATOR, None
-    )
-    if coordinator is None:
-        _LOGGER.error("Unfolded Circle coordinator not initialized")
-        connection.send_result(msg["id"])
-        return
-
+    """Unsubscribe events."""
+    # websocket_client = UCWebsocketClient(hass)
     cancel_callback = connection.subscriptions.get(msg["id"], None)
     if cancel_callback is not None:
         cancel_callback()
@@ -100,20 +102,201 @@ def ws_unsubscribe_event(
 )
 @callback
 def ws_subscribe_event(
-    hass: HomeAssistant,
-    connection: websocket_api.ActiveConnection,
-    msg: dict,
+        hass: HomeAssistant,
+        connection: websocket_api.ActiveConnection,
+        msg: dict,
 ) -> None:
     """Subscribe to incoming and outgoing events."""
-    if hass.data[DOMAIN] is None:
-        _LOGGER.error("Unfolded Circle integration not configured")
-        return
-
-    coordinator: UCClientInterface = (next(iter(hass.data[DOMAIN].values()))).get(
-        UNFOLDED_CIRCLE_COORDINATOR, None
-    )
-    if coordinator is None:
-        _LOGGER.error("Unfolded Circle coordinator not initialized")
-
-    coordinator.subscribe_entities_events(connection, msg)
+    websocket_client = UCWebsocketClient(hass)
+    websocket_client.subscribe_entities_events(connection, msg)
     connection.send_result(msg["id"])
+
+
+class Singleton(type):
+    """Singleton type to instantiate a single instance"""
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class UCWebsocketClient(metaclass=Singleton):
+    """Websocket client for remote HA integration
+
+    This class will handle commands received by the remote and events to send to notify the remote
+    of entities states changed
+    """
+
+    def __init__(self, hass: HomeAssistant):
+        self.hass = hass
+        # List of events to subscribe to the websocket
+        self._subscriptions: list[SubscriptionEvent] = []
+        self._configurations: list[SubscriptionEvent] = []
+        websocket_api.async_register_command(hass, ws_get_info)
+        websocket_api.async_register_command(hass, ws_subscribe_event)
+        websocket_api.async_register_command(hass, ws_unsubscribe_event)
+        _LOGGER.debug("Unfolded Circle websocket APIs registered. Ready to receive remotes requests")
+
+    async def close(self):
+        for subscription in self._subscriptions:
+            try:
+                _LOGGER.debug(
+                    "Unfolded Circle unregister event %s for remote %s",
+                    subscription.subscription_id,
+                    subscription.client_id,
+                )
+                subscription.cancel_subscription_callback()
+            except Exception:
+                pass
+        self._subscriptions = []
+
+    async def get_subscribed_entities(self, client_id: str) -> list[str] | None:
+        """Return subscribed entities of given client id (remote's host)"""
+        if client_id is None:
+            return None
+        # TODO better handling of client ids
+        client_id = client_id.split(":")[0]
+        for subscription in self._subscriptions:
+            if subscription.client_id.startswith(client_id):
+                return subscription.entity_ids
+        return None
+
+    async def send_configuration_to_remote(self, client_id: str, new_configuration: any) -> bool:
+        if client_id is None:
+            return False
+        # TODO better handling of client ids
+        client_id = client_id.split(":")[0]
+        configuration = None
+        for _configuration in self._configurations:
+            _LOGGER.debug("send_configuration_to_remote : %s", _configuration.client_id)
+            if _configuration.client_id.startswith(client_id):
+                configuration = _configuration
+                break
+
+        if configuration is None:
+            _LOGGER.warning(
+                "Unfolded Circle cannot notify remote %s for new configuration, it is not registered (%s)",
+                client_id,
+                new_configuration
+            )
+            return False
+        _LOGGER.debug("Notify new configuration to remote %s (%s)", client_id, new_configuration)
+        configuration.notification_callback({
+            "data": new_configuration
+        })
+        return True
+
+    def subscribe_entities_events(self, connection: websocket_api.ActiveConnection, msg: dict):
+        """Adds and handles subscribed event"""
+        subscription: SubscriptionEvent | None = None
+        cancel_callback: Callable[[], None] | None = None
+
+        @callback
+        def forward_event(data: dict[any, any]) -> None:
+            """Forward message to websocket subscription."""
+            connection.send_event(
+                msg["id"],
+                data,
+            )
+
+        def entities_state_change_event(event: Event[EventStateChangedData]) -> Any:
+            """Method called by HA when one of the subscribed entities have changed state."""
+            # Note that this method has to be encapsulated in the subscribe_entities_events method
+            # in order to maintain a reference to the subscription variable
+            entity_id = event.data["entity_id"]
+            old_state = event.data["old_state"]
+            new_state = event.data["new_state"]
+            _LOGGER.debug("Received notification to send to UC remote %s", event)
+            subscription.notification_callback(
+                {
+                    "data": {
+                        "entity_id": entity_id,
+                        "new_state": new_state,
+                        "old_state": old_state,  # TODO : old state useful ?
+                    }
+                }
+            )
+
+        def remove_listener() -> None:
+            """Remove the listener."""
+            try:
+                _LOGGER.debug(
+                    "Unfolded Circle unregister subscribe_entities_events %s for remote %s",
+                    subscription_id,
+                    client_id,
+                )
+                cancel_callback()
+            except Exception:
+                pass
+            self._subscriptions.remove(subscription)
+
+        # Create the new events subscription
+        subscription_id = msg["id"]
+        data = msg["data"]
+        entities = data.get("entities", [])
+        client_id = data.get("client_id", "")
+
+        cancel_callback = async_track_state_change_event(
+            self.hass, entities, entities_state_change_event
+        )
+        subscription = SubscriptionEvent(
+            client_id=client_id,
+            cancel_subscription_callback=cancel_callback,
+            subscription_id=subscription_id,
+            notification_callback=forward_event,
+            entity_ids=entities,
+        )
+        self._subscriptions.append(subscription)
+        _LOGGER.debug("UC added subscription from remote %s for entity ids %s", client_id, entities)
+
+        connection.subscriptions[subscription_id] = remove_listener
+
+        return remove_listener
+
+    def configure_entities_events(
+            self, connection: websocket_api.ActiveConnection, msg: dict
+    ):
+        """Subscribed event from remotes to receive new configuration data (entities to subscribe)"""
+        configuration: SubscriptionEvent | None = None
+        cancel_callback: Callable[[], None] | None = None
+
+        @callback
+        def forward_event(data: dict[any, any]) -> None:
+            """Forward message to websocket subscription."""
+            connection.send_event(
+                msg["id"],
+                data,
+            )
+
+        def remove_listener() -> None:
+            """Remove the listener."""
+            try:
+                _LOGGER.debug(
+                    "Unfolded Circle unregister configure_entities_events %s for remote %s",
+                    subscription_id,
+                    client_id,
+                )
+                cancel_callback()
+            except Exception:
+                pass
+            self._configurations.remove(configuration)
+
+        # Create the new events subscription
+        subscription_id = msg["id"]
+        data = msg["data"]
+        client_id = data.get("client_id", "")
+
+        configuration = SubscriptionEvent(
+            client_id=client_id,
+            cancel_subscription_callback=cancel_callback,
+            subscription_id=subscription_id,
+            notification_callback=forward_event,
+        )
+        self._subscriptions.append(configuration)
+        _LOGGER.debug("UC added configuration event from remote %s", client_id)
+
+        connection.subscriptions[subscription_id] = remove_listener
+
+        return remove_listener

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,8 @@
 # Home Assistant
-homeassistant>=2024.7.2
-home-assistant-frontend
-
-# Integration
-pyUnfoldedCircleRemote~=0.6.5
+homeassistant>=2024.8.3
+PyTurboJPEG
 
 # Development
 colorlog==6.7.0
-pip==24.1.2
-pylint>=3.0.3
-rel~=0.4.9.6
-requests~=2.32.3
-voluptuous~=0.13.1
-aiohttp~=3.9.3
-zeroconf~=0.131.0
-websockets~=12.0
-pyUnfoldedCircleRemote~=0.6.5
-ha-ffmpeg==3.2.0
+pip>=24.2
 ruff>=0.5.3
-PyTurboJPEG==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 # Home Assistant
-homeassistant>=2024.4
+homeassistant>=2024.7.2
 home-assistant-frontend
 
 # Integration
 pyUnfoldedCircleRemote~=0.6.5
 
 # Development
-black
 colorlog==6.7.0
-pip>=24.0
+pip==24.1.2
 pylint>=3.0.3
-ruff==0.0.255
 rel~=0.4.9.6
-requests~=2.31.0
+requests~=2.32.3
 voluptuous~=0.13.1
 aiohttp~=3.9.3
 zeroconf~=0.131.0
 websockets~=12.0
 pyUnfoldedCircleRemote~=0.6.5
-ha-ffmpeg
+ha-ffmpeg==3.2.0
+ruff>=0.5.3
+PyTurboJPEG==1.7.1


### PR DESCRIPTION
Several modifications here :

- Handle of new  event types from the HA driver : unfoldedcircle/event/configure/(un)subscribe in order to send the new entities configured from HA side to the HA driver and update the remote
- Handle of unfoldedcircle/event/entities/(un)subscribe in order to send the specific events that concern only the submitted entities
- Rework of the setup flow to integrate the selection of entities, as well as the config flow after setup to modify the list of subscribed entities.
- Rework of the websocket interface initially loaded on the coordinator but problematic : no coordinator exist if no remote is configured, multiple coordinators so duplicate subscriptions if multiple remotes configured. Websocket is now instantiated as singleton from multiple places : from coordinator, from config flow and especially during zeroconf config flow which is useful to get an instance BEFORE the user starts the config flow and get events then.
- Some updates to support webconfigurator, and update of the regex for Remote 3 (TBC)
- Other modifications I don't remember :-)