### PR TITLE
Fix Websockets Version

### DIFF
--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": [
-    "websockets==12.0",
+    "websockets>=12.0",
     "pyUnfoldedCircleRemote==0.11.11",
     "wakeonlan==3.1.0"
   ],

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": [
-    "websockets>=12.0",
+    "websockets>=12.0,<14",
     "pyUnfoldedCircleRemote==0.11.11",
     "wakeonlan==3.1.0"
   ],


### PR DESCRIPTION
Aims to resolve incompatibility issues with the Ring native integration in Home Assistant, by allowing versions of websockets above v. 12 (13 is required by ring).

Tested in local environment and appears to work without issues.