### PR TITLE
Fixed removal of subscribed entities and manual setup flow failure

### DIFF
--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er, issue_registry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
+from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 from .const import DOMAIN, UC_HA_SYSTEM, UC_HA_TOKEN_ID
 from .coordinator import (

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -15,10 +15,10 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from pyUnfoldedCircleRemote.remote import Remote
-from pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
-from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
-from pyUnfoldedCircleRemote.dock import Dock
+from .pyUnfoldedCircleRemote.remote import Remote
+from .pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
+from .pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
+from .pyUnfoldedCircleRemote.dock import Dock
 
 from .const import DEVICE_SCAN_INTERVAL, DOMAIN, DEBUG_UC_MSG
 from .websocket import UCWebsocketClient

--- a/custom_components/unfoldedcircle/helpers.py
+++ b/custom_components/unfoldedcircle/helpers.py
@@ -7,8 +7,8 @@ import re
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
-from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
-from pyUnfoldedCircleRemote.remote import (
+from .pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
+from .pyUnfoldedCircleRemote.remote import (
     HTTPError,
     IntegrationNotFound,
     Remote,
@@ -119,13 +119,16 @@ async def validate_and_register_system_and_driver(
     creates the driver instance if one doesn't exist"""
     if validate_websocket_address(websocket_url):
         if not await validate_tokens(hass, remote):
+            _LOGGER.debug("No valid external token, register one")
             return await register_system_and_driver(remote, hass, websocket_url)
         return await connect_integration(remote, driver_id=UC_HA_SYSTEM)
 
 
 async def connect_integration(remote: Remote, driver_id=UC_HA_SYSTEM) -> str:
     """Attempt to connect the Home Assistant Integration"""
+    ha_driver_instance = {}
     try:
+        _LOGGER.debug("Home assistant driver integration lookup for system %s", driver_id)
         ha_driver_instance = await remote.get_integration_instance_by_driver_id(
             driver_id
         )

--- a/custom_components/unfoldedcircle/media_player.py
+++ b/custom_components/unfoldedcircle/media_player.py
@@ -18,8 +18,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UndefinedType
 from homeassistant.util import utcnow
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
-from pyUnfoldedCircleRemote.remote import (
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.remote import (
     Activity,
     ActivityGroup,
     UCMediaPlayerEntity,

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -972,6 +972,19 @@ class Remote:
             await self.raise_on_error(response)
             return True
 
+    async def delete_remote_entity(
+        self, entity_id: str
+    ) -> bool:
+        """Delete the given entity ID on the remote."""
+        async with (
+            self.client() as session,
+            session.delete(
+                self.url(f"entities/{entity_id}")
+            ) as response,
+        ):
+            await self.raise_on_error(response)
+            return True
+
     async def get_remote_subscribed_entities(
         self, integration_id: str
     ) -> list[dict[str, any]]:

--- a/custom_components/unfoldedcircle/remote.py
+++ b/custom_components/unfoldedcircle/remote.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import service, entity_platform
 from homeassistant.helpers.entity import ToggleEntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
-from pyUnfoldedCircleRemote.remote import AuthenticationError, DockNotFound
+from .pyUnfoldedCircleRemote.remote import AuthenticationError, DockNotFound
 
 from .const import (
     DOMAIN,

--- a/custom_components/unfoldedcircle/select.py
+++ b/custom_components/unfoldedcircle/select.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import (
     CONF_SUPPRESS_ACTIVITIY_GROUPS,

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.const import RemoteUpdateType
+from .pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import CONF_ACTIVITIES_AS_SWITCHES, UPDATE_ACTIVITY_SERVICE, DOMAIN
 from .coordinator import UnfoldedCircleRemoteCoordinator

--- a/custom_components/unfoldedcircle/update.py
+++ b/custom_components/unfoldedcircle/update.py
@@ -13,7 +13,7 @@ from homeassistant.components.update import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from pyUnfoldedCircleRemote.remote import HTTPError
+from .pyUnfoldedCircleRemote.remote import HTTPError
 
 from .entity import UnfoldedCircleEntity
 from . import UnfoldedCircleConfigEntry

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Home Assistant
-homeassistant>=2024.12
+homeassistant~=2024.11.3
 PyTurboJPEG
 
 # Development
@@ -9,3 +9,14 @@ ruff>=0.5.3
 aiohttp_fast_zlib
 zlib_ng
 isal
+rel~=0.4.9.9
+logging~=0.4.9.6
+websockets~=12.0
+requests~=2.32.3
+Pygments~=2.17.2
+zeroconf~=0.131.0
+voluptuous~=0.15.2
+pyUnfoldedCircleRemote~=0.9.2
+aiohttp~=3.9.5
+wakeonlan~=3.1.0
+packaging~=24.0


### PR DESCRIPTION
Hi Jack,

I have tested the following workaround to remove entities and it is working : send the rebuilt entity ID from integration id and HA entity ID. Not a clean approach but it is working
I also fixed an issue with manual setup flow

Damien