### PR TITLE
Added new sensor to track the synchronized entities + a last config step to make all available entities as configured or not

### DIFF
--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er, issue_registry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from .pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
+from pyUnfoldedCircleRemote.remote import AuthenticationError, Remote
 
 from .const import DOMAIN, UC_HA_SYSTEM, UC_HA_TOKEN_ID
 from .coordinator import (

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -4,8 +4,8 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Type
 
-from .pyUnfoldedCircleRemote.const import AUTH_APIKEY_NAME, SIMULATOR_MAC_ADDRESS
-from .pyUnfoldedCircleRemote.remote import (
+from pyUnfoldedCircleRemote.const import AUTH_APIKEY_NAME, SIMULATOR_MAC_ADDRESS
+from pyUnfoldedCircleRemote.remote import (
     ApiKeyCreateError,
     ApiKeyRevokeError,
     AuthenticationError,
@@ -718,7 +718,8 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
 
 
 async def async_step_select_entities(
-    config_flow: UnfoldedCircleRemoteConfigFlow | UnfoldedCircleRemoteOptionsFlowHandler,
+    config_flow: UnfoldedCircleRemoteConfigFlow
+    | UnfoldedCircleRemoteOptionsFlowHandler,
     hass: HomeAssistant,
     remote: Remote,
     finish_callback: Callable[[dict[str, Any] | None], Awaitable[FlowResult]],
@@ -799,7 +800,7 @@ async def async_step_select_entities(
             "Found configuration subscription for remote %s (subscription_id %s) : entities %s",
             configure_entities_subscription.client_id,
             configure_entities_subscription.subscription_id,
-            configure_entities_subscription.entity_ids
+            configure_entities_subscription.entity_ids,
         )
         subscribed_entities: list[str] = []
         if subscribed_entities_subscription:
@@ -807,7 +808,7 @@ async def async_step_select_entities(
                 "Found subscribed entities for remote %s (subscription_id %s) : %s",
                 subscribed_entities_subscription.client_id,
                 subscribed_entities_subscription.subscription_id,
-                subscribed_entities_subscription.entity_ids
+                subscribed_entities_subscription.entity_ids,
             )
             subscribed_entities = subscribed_entities_subscription.entity_ids
 
@@ -817,8 +818,11 @@ async def async_step_select_entities(
 
         # Only in option flow : retrieve configured available entities stored in the integration
         # and add them to the list if not present
-        if (isinstance(config_flow, UnfoldedCircleRemoteOptionsFlowHandler) and config_flow.options
-                and config_flow.options.get("available_entities", None)):
+        if (
+            isinstance(config_flow, UnfoldedCircleRemoteOptionsFlowHandler)
+            and config_flow.options
+            and config_flow.options.get("available_entities", None)
+        ):
             entities = config_flow.options["available_entities"]
             for entity_id in entities:
                 if entity_id not in available_entities:
@@ -916,18 +920,28 @@ async def async_step_select_entities(
 
             # Entities sent successfully to the HA driver, store the list in the registry
             # If Option flow
-            if isinstance(config_flow, UnfoldedCircleRemoteOptionsFlowHandler) and config_flow.options:
+            if (
+                isinstance(config_flow, UnfoldedCircleRemoteOptionsFlowHandler)
+                and config_flow.options
+            ):
                 if config_flow.options is None:
                     config_flow.options = {}
                 config_flow.options["available_entities"] = final_list
                 if configure_entities_subscription:
-                    config_flow.options["client_id"] = subscribed_entities_subscription.client_id
-            elif isinstance(config_flow, UnfoldedCircleRemoteConfigFlow) and config_flow.info:
+                    config_flow.options["client_id"] = (
+                        subscribed_entities_subscription.client_id
+                    )
+            elif (
+                isinstance(config_flow, UnfoldedCircleRemoteConfigFlow)
+                and config_flow.info
+            ):
                 if config_flow.info is None:
                     config_flow.info = {}
                 config_flow.info["available_entities"] = final_list
                 if configure_entities_subscription:
-                    config_flow.info["client_id"] = subscribed_entities_subscription.client_id
+                    config_flow.info["client_id"] = (
+                        subscribed_entities_subscription.client_id
+                    )
 
             # Subscribe to the new entities if requested by user
             if do_subscribed_entities:

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -522,7 +522,7 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self.options = dict(config_entry.options)
         self._remote: Remote | None = None
         self._websocket_client: UCWebsocketClient | None = None
@@ -530,9 +530,9 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_connect_remote(self) -> any:
         self._remote = Remote(
-            self.config_entry.data["host"],
-            self.config_entry.data["pin"],
-            self.config_entry.data["apiKey"],
+            self._config_entry.data["host"],
+            self._config_entry.data["pin"],
+            self._config_entry.data["apiKey"],
         )
         await self._remote.validate_connection()
         await self._remote.get_version()
@@ -563,13 +563,13 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_ACTIVITIES_AS_SWITCHES,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_ACTIVITIES_AS_SWITCHES, False
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SUPPRESS_ACTIVITIY_GROUPS,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SUPPRESS_ACTIVITIY_GROUPS, False
                         ),
                     ): bool,
@@ -592,19 +592,19 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_GLOBAL_MEDIA_ENTITY,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_GLOBAL_MEDIA_ENTITY, True
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_ACTIVITY_GROUP_MEDIA_ENTITIES,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_ACTIVITY_GROUP_MEDIA_ENTITIES, False
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_ACTIVITY_MEDIA_ENTITIES,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_ACTIVITY_MEDIA_ENTITIES, False
                         ),
                     ): bool,

--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -490,36 +490,6 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input,
         )
 
-    async def async_step_subscribe(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Subscribe all available entities Step"""
-        subscribed_entities_subscription = None
-        try:
-            subscribed_entities_subscription = self._websocket_client.get_subscribed_entities(
-                self._remote.hostname
-            )
-            integration_id = await connect_integration(
-                self._remote, subscribed_entities_subscription.driver_id
-            )
-            await self._remote.get_remote_integration_entities(integration_id, True)
-
-            await self._remote.set_remote_integration_entities(integration_id, [])
-            _LOGGER.debug(
-                "Entities registered successfully for: %s", integration_id
-            )
-            return await self.async_step_finish(None)
-        except Exception as ex:
-            _LOGGER.error(
-                "Failed to subscribe the remote %s with the new entities (%s) : %s",
-                self._remote.hostname,
-                subscribed_entities_subscription, ex
-            )
-            return self.async_show_menu(
-                step_id="select_entities",
-                menu_options=["error", "finish"],
-            )
-
     async def async_step_finish(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -740,37 +710,6 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
                     user_input,
                 )
 
-    async def async_step_subscribe(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Subscribe all available entities Step"""
-        subscribed_entities_subscription = None
-        try:
-            subscribed_entities_subscription = self._websocket_client.get_subscribed_entities(
-                self._remote.hostname
-            )
-            integration_id = await connect_integration(
-                self._remote, subscribed_entities_subscription.driver_id
-            )
-            await self._remote.get_remote_integration_entities(integration_id, True)
-
-            await self._remote.set_remote_integration_entities(integration_id, [])
-            _LOGGER.debug(
-                "Entities registered successfully for: %s", integration_id
-            )
-            return await self.async_step_finish(None)
-        except Exception as ex:
-            _LOGGER.error(
-                "Failed to subscribe the remote %s with the new entities (%s) : %s",
-                self._remote.hostname,
-                subscribed_entities_subscription, ex
-            )
-            return self.async_show_menu(
-                step_id="select_entities",
-                menu_options=["error", "finish"],
-            )
-
-
     async def async_step_finish(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -908,6 +847,8 @@ async def async_step_select_entities(
             }
             data_schema.update({"remove_entities": EntitySelector(config)})
 
+        data_schema.update({vol.Required("subscribe_entities", default=True): bool})
+
         _LOGGER.debug("Add/removal of entities %s", data_schema)
         return config_flow.async_show_form(
             step_id="select_entities",
@@ -942,6 +883,8 @@ async def async_step_select_entities(
 
         add_entities = user_input.get("add_entities", [])
         remove_entities = user_input.get("remove_entities", [])
+        do_subscribed_entities = user_input.get("subscribe_entities", True)
+
         final_list = set(subscribed_entities) - set(remove_entities)
         final_list.update(add_entities)
         final_list = list(final_list)
@@ -986,29 +929,28 @@ async def async_step_select_entities(
                 if configure_entities_subscription:
                     config_flow.info["client_id"] = subscribed_entities_subscription.client_id
 
-            # # Subscribe to the new entities : only if older version of HA driver
-            # if configure_entities_subscription.version is None or configure_entities_subscription.version == "":
-            #     try:
-            #         integration_id = await connect_integration(
-            #             remote, subscribed_entities_subscription.driver_id
-            #         )
-            #         await remote.get_remote_integration_entities(integration_id, True)
-            #
-            #         await remote.set_remote_integration_entities(integration_id, [])
-            #         _LOGGER.debug(
-            #             "Entities registered successfully for: %s", integration_id
-            #         )
-            #         return await finish_callback(None)
-            #     except IntegrationNotFound:
-            #         _LOGGER.error(
-            #             "Failed to notify remote with the new entities %s for driver id %s",
-            #             remote.hostname,
-            #             subscribed_entities_subscription.driver_id,
-            #         )
-            #         return config_flow.async_show_menu(
-            #             step_id="select_entities",
-            #             menu_options=["error", "finish"],
-            #         )
+            # Subscribe to the new entities if requested by user
+            if do_subscribed_entities:
+                try:
+                    integration_id = await connect_integration(
+                        remote, subscribed_entities_subscription.driver_id
+                    )
+                    await remote.get_remote_integration_entities(integration_id, True)
+
+                    await remote.set_remote_integration_entities(integration_id, [])
+                    _LOGGER.debug(
+                        "Entities registered successfully for: %s", integration_id
+                    )
+                except IntegrationNotFound:
+                    _LOGGER.error(
+                        "Failed to notify remote with the new entities %s for driver id %s",
+                        remote.hostname,
+                        subscribed_entities_subscription.driver_id,
+                    )
+                    return config_flow.async_show_menu(
+                        step_id="select_entities",
+                        menu_options=["error", "finish"],
+                    )
 
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.error(
@@ -1022,11 +964,7 @@ async def async_step_select_entities(
                 menu_options=["error", "finish"],
             )
         _LOGGER.debug("Entities registered successfully, finishing config flow")
-        return config_flow.async_show_menu(
-            step_id="select_entities",
-            menu_options=["subscribe", "finish"],
-        )
-        # return await finish_callback(None)
+        return await finish_callback(None)
 
 
 class CannotConnect(HomeAssistantError):

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -15,10 +15,10 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
-from .pyUnfoldedCircleRemote.remote import Remote
-from .pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
-from .pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
-from .pyUnfoldedCircleRemote.dock import Dock
+from pyUnfoldedCircleRemote.remote import Remote
+from pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
+from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
+from pyUnfoldedCircleRemote.dock import Dock
 
 from .const import DEVICE_SCAN_INTERVAL, DOMAIN, DEBUG_UC_MSG
 from .websocket import UCWebsocketClient

--- a/custom_components/unfoldedcircle/helpers.py
+++ b/custom_components/unfoldedcircle/helpers.py
@@ -7,8 +7,8 @@ import re
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
-from .pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
-from .pyUnfoldedCircleRemote.remote import (
+from pyUnfoldedCircleRemote.dock_websocket import DockWebsocket
+from pyUnfoldedCircleRemote.remote import (
     HTTPError,
     IntegrationNotFound,
     Remote,
@@ -20,7 +20,13 @@ from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
-from .const import UC_HA_SYSTEM, UC_HA_TOKEN_ID, DEFAULT_HASS_URL, DOMAIN, UC_HA_DRIVER_ID
+from .const import (
+    DEFAULT_HASS_URL,
+    DOMAIN,
+    UC_HA_DRIVER_ID,
+    UC_HA_SYSTEM,
+    UC_HA_TOKEN_ID,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,7 +134,9 @@ async def connect_integration(remote: Remote, driver_id=UC_HA_DRIVER_ID) -> str:
     """Attempt to connect the Home Assistant Integration"""
     ha_driver_instance = {}
     try:
-        _LOGGER.debug("Home assistant driver integration lookup for system %s", driver_id)
+        _LOGGER.debug(
+            "Home assistant driver integration lookup for system %s", driver_id
+        )
         ha_driver_instance = await remote.get_integration_instance_by_driver_id(
             driver_id
         )

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": [
     "websockets>=12.0,<14",
-    "pyUnfoldedCircleRemote==0.12.3",
+    "pyUnfoldedCircleRemote==0.12.4",
     "wakeonlan==3.1.0"
   ],
   "version": "0.14.0",

--- a/custom_components/unfoldedcircle/media_player.py
+++ b/custom_components/unfoldedcircle/media_player.py
@@ -18,8 +18,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UndefinedType
 from homeassistant.util import utcnow
-from .pyUnfoldedCircleRemote.const import RemoteUpdateType
-from .pyUnfoldedCircleRemote.remote import (
+from pyUnfoldedCircleRemote.const import RemoteUpdateType
+from pyUnfoldedCircleRemote.remote import (
     Activity,
     ActivityGroup,
     UCMediaPlayerEntity,

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -862,8 +862,7 @@ class Remote:
             if self._is_simulator is True:
                 core = information.get("core", "")
                 # We only care about the beginning of the version for this compare
-                if Version(core[0:4]) >= Version("0.49"):
-                    self._external_entity_configuration_available = True
+                self._external_entity_configuration_available = True
             else:
                 self._sw_version = information.get("os", "")
                 if Version(self._sw_version) >= Version("2.0.0"):

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -862,7 +862,8 @@ class Remote:
             if self._is_simulator is True:
                 core = information.get("core", "")
                 # We only care about the beginning of the version for this compare
-                self._external_entity_configuration_available = True
+                if Version(core[0:4]) >= Version("0.49"):
+                    self._external_entity_configuration_available = True
             else:
                 self._sw_version = information.get("os", "")
                 if Version(self._sw_version) >= Version("2.0.0"):
@@ -971,15 +972,11 @@ class Remote:
             await self.raise_on_error(response)
             return True
 
-    async def delete_remote_entity(
-        self, entity_id: str
-    ) -> bool:
+    async def delete_remote_entity(self, entity_id: str) -> bool:
         """Delete the given entity ID on the remote."""
         async with (
             self.client() as session,
-            session.delete(
-                self.url(f"entities/{entity_id}")
-            ) as response,
+            session.delete(self.url(f"entities/{entity_id}")) as response,
         ):
             await self.raise_on_error(response)
             return True

--- a/custom_components/unfoldedcircle/remote.py
+++ b/custom_components/unfoldedcircle/remote.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import service, entity_platform
 from homeassistant.helpers.entity import ToggleEntityDescription
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
-from .pyUnfoldedCircleRemote.remote import AuthenticationError, DockNotFound
+from pyUnfoldedCircleRemote.remote import AuthenticationError, DockNotFound
 
 from .const import (
     DOMAIN,

--- a/custom_components/unfoldedcircle/repairs.py
+++ b/custom_components/unfoldedcircle/repairs.py
@@ -53,14 +53,19 @@ class DockPasswordRepairFlow(RepairsFlow):
                 is_valid = await validate_dock_password(self.coordinator.api, self.data)
                 if is_valid:
                     config_data = existing_entry
-                    _LOGGER.debug("Updating dock password %s (%s) for remote %s",
-                                  self.data.get("name"), self.data.get("id"),
-                                  self.config_entry.title)
+                    _LOGGER.debug(
+                        "Updating dock password %s (%s) for remote %s",
+                        self.data.get("name"),
+                        self.data.get("id"),
+                        self.config_entry.title,
+                    )
                     for info in config_data.data["docks"]:
                         if info.get("id") == self.data.get("id"):
                             info["password"] = self.data["password"]
                             # Update password of the same dock for other remotes
-                            await synchronize_dock_password(self.hass, info, existing_entry.entry_id)
+                            await synchronize_dock_password(
+                                self.hass, info, existing_entry.entry_id
+                            )
                     self.hass.config_entries.async_update_entry(
                         existing_entry, data=config_data.data
                     )

--- a/custom_components/unfoldedcircle/select.py
+++ b/custom_components/unfoldedcircle/select.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .pyUnfoldedCircleRemote.const import RemoteUpdateType
+from pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import (
     CONF_SUPPRESS_ACTIVITIY_GROUPS,

--- a/custom_components/unfoldedcircle/sensor.py
+++ b/custom_components/unfoldedcircle/sensor.py
@@ -94,8 +94,8 @@ UNFOLDED_CIRCLE_SENSOR: tuple[UnfoldedCircleSensorEntityDescription, ...] = (
         icon="mdi:remote",
         suggested_display_precision=0,
         entity_registry_enabled_default=True,
-        entity_registry_visible_default=True,
-    )
+        entity_registry_visible_default=False,
+    ),
 )
 
 
@@ -154,10 +154,12 @@ class UnfoldedCircleSensor(UnfoldedCircleEntity, SensorEntity):
         if self.entity_description.key == "remote_entities":
             self._attr_extra_state_attributes = {"Synchronized entities": 0}
             if self.coordinator.config_entry.data.get("available_entities", None):
-                self._attr_extra_state_attributes["Available entities"] = self.coordinator.config_entry.data.get(
-                    "available_entities", [])
-                self._attr_extra_state_attributes["Synchronized entities"] = (
-                    len(self._attr_extra_state_attributes["Available entities"]))
+                self._attr_extra_state_attributes["Available entities"] = (
+                    self.coordinator.config_entry.data.get("available_entities", [])
+                )
+                self._attr_extra_state_attributes["Synchronized entities"] = len(
+                    self._attr_extra_state_attributes["Available entities"]
+                )
 
         await super().async_added_to_hass()
 

--- a/custom_components/unfoldedcircle/sensor.py
+++ b/custom_components/unfoldedcircle/sensor.py
@@ -132,6 +132,7 @@ class UnfoldedCircleSensor(UnfoldedCircleEntity, SensorEntity):
         self._attr_entity_category = description.entity_category
         self.entity_description = description
         self._state: StateType = None
+        self._attr_extra_state_attributes = {}
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""

--- a/custom_components/unfoldedcircle/sensor.py
+++ b/custom_components/unfoldedcircle/sensor.py
@@ -20,7 +20,7 @@ from .entity import UnfoldedCircleEntity
 from . import UnfoldedCircleConfigEntry
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnfoldedCircleSensorEntityDescription(SensorEntityDescription):
     """Class describing Unfolded Circle Remote sensor entities."""
 
@@ -86,6 +86,16 @@ UNFOLDED_CIRCLE_SENSOR: tuple[UnfoldedCircleSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         entity_registry_visible_default=False,
     ),
+    UnfoldedCircleSensorEntityDescription(
+        key="remote_entities",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        name="Remote entities",
+        unique_id="remote_entities",
+        icon="mdi:remote",
+        suggested_display_precision=0,
+        entity_registry_enabled_default=True,
+        entity_registry_visible_default=True,
+    )
 )
 
 
@@ -139,10 +149,21 @@ class UnfoldedCircleSensor(UnfoldedCircleEntity, SensorEntity):
             "cpu_load_one",
         ]:
             self.coordinator.polling_data = True
+
+        if self.entity_description.key == "remote_entities":
+            self._attr_extra_state_attributes = {"Synchronized entities": 0}
+            if self.coordinator.config_entry.data.get("available_entities", None):
+                self._attr_extra_state_attributes["Available entities"] = self.coordinator.config_entry.data.get(
+                    "available_entities", [])
+                self._attr_extra_state_attributes["Synchronized entities"] = (
+                    len(self._attr_extra_state_attributes["Available entities"]))
+
         await super().async_added_to_hass()
 
     def get_value(self) -> StateType:
         """return native value of entity"""
+        if self.entity_description.key == "remote_entities":
+            return self._attr_extra_state_attributes.get("Synchronized entities", 0)
         if self.coordinator.data:
             self._state = getattr(self.coordinator.api, self.entity_description.key)
             self._attr_native_value = self._state

--- a/custom_components/unfoldedcircle/switch.py
+++ b/custom_components/unfoldedcircle/switch.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform, service
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .pyUnfoldedCircleRemote.const import RemoteUpdateType
+from pyUnfoldedCircleRemote.const import RemoteUpdateType
 
 from .const import CONF_ACTIVITIES_AS_SWITCHES, UPDATE_ACTIVITY_SERVICE, DOMAIN
 from .coordinator import UnfoldedCircleRemoteCoordinator

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -34,7 +34,7 @@
         "data": {
           "add_entities": "Entities to share with Remote",
           "remove_entities": "Entities to remove from Remote",
-          "subscribe_entities": "Make all synchronized entities as configured"
+          "subscribe_entities": "Automatically configure entities shared with Remote"
         },
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
@@ -101,7 +101,7 @@
         "data": {
           "add_entities": "Entities to share with Remote",
           "remove_entities": "Entities to remove from Remote",
-          "subscribe_entities": "Make all synchronized entities as configured"
+          "subscribe_entities": "Automatically configure entities shared with Remote"
         },
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -38,7 +38,8 @@
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?"
+          "error": "Unable to communicate with the remote. Retry?",
+          "subscribe": "Make all synchronized entities as configured"
         }
       },
       "zeroconf_confirm": {
@@ -104,7 +105,8 @@
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?"
+          "error": "Unable to communicate with the remote. Retry?",
+          "subscribe": "Make all synchronized entities as configured"
         }
       }
     }

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -33,13 +33,13 @@
         "title": "Configure Entities (Optional)",
         "data": {
           "add_entities": "Entities to share with Remote",
-          "remove_entities": "Entities to remove from Remote"
+          "remove_entities": "Entities to remove from Remote",
+          "subscribe_entities": "Make all synchronized entities as configured"
         },
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?",
-          "subscribe": "Make all synchronized entities as configured"
+          "error": "Unable to communicate with the remote. Retry?"
         }
       },
       "zeroconf_confirm": {
@@ -100,13 +100,13 @@
         "title": "Configure Entities",
         "data": {
           "add_entities": "Entities to share with Remote",
-          "remove_entities": "Entities to remove from Remote"
+          "remove_entities": "Entities to remove from Remote",
+          "subscribe_entities": "Make all synchronized entities as configured"
         },
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?",
-          "subscribe": "Make all synchronized entities as configured"
+          "error": "Unable to communicate with the remote. Retry?"
         }
       }
     }

--- a/custom_components/unfoldedcircle/translations/fr.json
+++ b/custom_components/unfoldedcircle/translations/fr.json
@@ -33,13 +33,13 @@
         "title": "Configure Entities (Optional)",
         "data": {
           "add_entities": "Entities to share with Remote",
-          "remove_entities": "Entities to remove from Remote"
+          "remove_entities": "Entities to remove from Remote",
+          "subscribe_entities": "Activer toutes les entités synchronisées"
         },
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?",
-          "subscribe": "Activer toutes les entités synchronisées"
+          "error": "Unable to communicate with the remote. Retry?"
         }
       },
       "zeroconf_confirm": {
@@ -88,13 +88,13 @@
         "title": "Configurer les entités",
         "data": {
           "add_entities": "Entités à ajouter à la télécommande",
-          "remove_entities": "Entités à retirer de la télécommande"
+          "remove_entities": "Entités à retirer de la télécommande",
+          "subscribe_entities": "Activer toutes les entités synchronisées"
         },
         "menu_options": {
           "remote_websocket": "La télécommande n'est pas connectée, essayez de reconfigurer l'adresse",
           "finish": "Ignorer cette étape et terminer",
-          "error": "Impossible de commmuniquer avec la télécommande. Réessayer ?",
-          "subscribe": "Activer toutes les entités synchronisées"
+          "error": "Impossible de commmuniquer avec la télécommande. Réessayer ?"
         }
       }
     }

--- a/custom_components/unfoldedcircle/translations/fr.json
+++ b/custom_components/unfoldedcircle/translations/fr.json
@@ -38,7 +38,8 @@
         "menu_options": {
           "remote_websocket": "Remote is not connected, try to reconfigure the URL",
           "finish": "Ignore this step and finish",
-          "error": "Unable to communicate with the remote. Retry?"
+          "error": "Unable to communicate with the remote. Retry?",
+          "subscribe": "Activer toutes les entités synchronisées"
         }
       },
       "zeroconf_confirm": {
@@ -92,7 +93,8 @@
         "menu_options": {
           "remote_websocket": "La télécommande n'est pas connectée, essayez de reconfigurer l'adresse",
           "finish": "Ignorer cette étape et terminer",
-          "error": "Impossible de commmuniquer avec la télécommande. Réessayer ?"
+          "error": "Impossible de commmuniquer avec la télécommande. Réessayer ?",
+          "subscribe": "Activer toutes les entités synchronisées"
         }
       }
     }

--- a/custom_components/unfoldedcircle/update.py
+++ b/custom_components/unfoldedcircle/update.py
@@ -13,7 +13,7 @@ from homeassistant.components.update import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from .pyUnfoldedCircleRemote.remote import HTTPError
+from pyUnfoldedCircleRemote.remote import HTTPError
 
 from .entity import UnfoldedCircleEntity
 from . import UnfoldedCircleConfigEntry

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -62,7 +62,7 @@ def ws_get_info(
             "success": True,
             "result": {"state": "CONNECTED", "cat": "DEVICE", "version": "1.0.0"},
             "message": msg.get("message"),
-            "data": data
+            "data": data,
         }
     )
 
@@ -77,7 +77,7 @@ def ws_get_states(
     """Handle get info command."""
     _LOGGER.debug("Unfolded Circle get entities states request from remote %s", msg)
     entity_ids: list[str] = msg.get("data", {}).get("entity_ids", [])
-    client_id: str|None = msg.get("data", {}).get("client_id", None)
+    client_id: str | None = msg.get("data", {}).get("client_id", None)
     entity_states = []
     # If entity_ids list is empty, send all entities
     if len(entity_ids) == 0:
@@ -88,12 +88,20 @@ def ws_get_states(
         if client_id:
             existing_entries = hass.config_entries.async_entries(domain=DOMAIN)
             try:
-                config_entry = next(config_entry for config_entry in existing_entries
-                                    if config_entry.data.get("client_id", "") == client_id)
+                config_entry = next(
+                    config_entry
+                    for config_entry in existing_entries
+                    if config_entry.data.get("client_id", "") == client_id
+                )
                 if config_entry:
-                    _LOGGER.debug("Unfolded circle get states from client %s, config entry found %s",
-                                  client_id, config_entry.title)
-                    available_entities = config_entry.data.get("available_entities", []).copy()
+                    _LOGGER.debug(
+                        "Unfolded circle get states from client %s, config entry found %s",
+                        client_id,
+                        config_entry.title,
+                    )
+                    available_entities = config_entry.data.get(
+                        "available_entities", []
+                    ).copy()
                     update_needed = False
                     for entity_id in entity_ids:
                         if entity_id not in available_entities:
@@ -102,20 +110,30 @@ def ws_get_states(
                     if update_needed:
                         data = dict(config_entry.data)
                         data["available_entities"] = available_entities
-                        _LOGGER.debug("Available entities need to be updated in registry as there is "
-                                      "a desync with the remote %s. "
-                                      "Remote : %s, HA registry : %s",
-                                      client_id,
-                                      config_entry.data.get("available_entities", []),
-                                      available_entities)
+                        _LOGGER.debug(
+                            "Available entities need to be updated in registry as there is "
+                            "a desync with the remote %s. "
+                            "Remote : %s, HA registry : %s",
+                            client_id,
+                            config_entry.data.get("available_entities", []),
+                            available_entities,
+                        )
                         hass.config_entries.async_update_entry(config_entry, data=data)
                 else:
-                    _LOGGER.debug("Unfolded circle get states from client %s : no config entry", client_id)
+                    _LOGGER.debug(
+                        "Unfolded circle get states from client %s : no config entry",
+                        client_id,
+                    )
             except StopIteration:
-                _LOGGER.debug("Unfolded circle get states from client %s : no config entry", client_id)
+                _LOGGER.debug(
+                    "Unfolded circle get states from client %s : no config entry",
+                    client_id,
+                )
                 pass
         else:
-            _LOGGER.debug("No client ID in the request from remote, cannot update the available entities in HA")
+            _LOGGER.debug(
+                "No client ID in the request from remote, cannot update the available entities in HA"
+            )
 
         # Add the missing available entities (normally the unsubscribed entities) to the get states command
         for entity_id in available_entities:

--- a/custom_components/unfoldedcircle/websocket.py
+++ b/custom_components/unfoldedcircle/websocket.py
@@ -404,6 +404,7 @@ class UCWebsocketClient(metaclass=Singleton):
         entities = data.get("entities", [])
         client_id = data.get("client_id", "")
         driver_id = data.get("driver_id", UC_HA_DRIVER_ID)
+        version = data.get("version", "")
 
         cancel_callback = async_track_state_change_event(
             self.hass, entities, entities_state_change_event
@@ -411,6 +412,7 @@ class UCWebsocketClient(metaclass=Singleton):
         subscription = SubscriptionEvent(
             client_id=client_id,
             driver_id=driver_id,
+            version=version,
             cancel_subscription_callback=cancel_callback,
             subscription_id=subscription_id,
             notification_callback=forward_event,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Home Assistant
-homeassistant~=2024.11.3
+homeassistant>=2024.12
 PyTurboJPEG
 
 # Development
@@ -9,14 +9,3 @@ ruff>=0.5.3
 aiohttp_fast_zlib
 zlib_ng
 isal
-rel~=0.4.9.9
-logging~=0.4.9.6
-websockets~=12.0
-requests~=2.32.3
-Pygments~=2.17.2
-zeroconf~=0.131.0
-voluptuous~=0.15.2
-pyUnfoldedCircleRemote~=0.9.2
-aiohttp~=3.9.5
-wakeonlan~=3.1.0
-packaging~=24.0


### PR DESCRIPTION
New proposition :

- Added new sensor to track the synchronized entities (number of entities) + an attribute within this sensor with the list of these entities
- Added a last config step to make all available entities as configured or not : this is maybe a good compromise : it lets the user to decide if all the selected entities should be enabled or not (switched from available to configured)