### PR TITLE
Only maintain ws during learning

### DIFF
--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -156,7 +156,6 @@ async def async_setup_entry(
             try:
                 await dock_coordinator.api.update()
                 await dock_coordinator.async_config_entry_first_refresh()
-                await dock_coordinator.init_websocket()
                 dock_coordinators.append(dock_coordinator)
             except Exception as ex:
                 _LOGGER.error(

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -198,11 +198,7 @@ class UnfoldedCircleDockCoordinator(
         self.hass = hass
         self.api: Dock = dock
         self.data = {}
-        self.websocket = DockWebsocket(
-            self.api._ws_endpoint,
-            api_key=dock.apikey,
-            dock_password=self.api.password,
-        )
+        self.websocket = None
         self.websocket_task = None
         self.subscribe_events = {}
         self.polling_data = False
@@ -212,6 +208,14 @@ class UnfoldedCircleDockCoordinator(
 
     async def init_websocket(self):
         """Initialize the Web Socket"""
+
+        if not self.websocket:
+            self.websocket = DockWebsocket(
+                self.api._ws_endpoint,
+                api_key=self.api.apikey,
+                dock_password=self.api.password,
+            )
+
         self.websocket.events_to_subscribe = [
             "all",
             *list(self.subscribe_events.keys()),

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock_websocket.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/dock_websocket.py
@@ -147,6 +147,8 @@ class DockWebsocket(Websocket):
                                     "UnfoldedCircleRemote exception in websocket receive callback %s",
                                     ex,
                                 )
+                            finally:
+                                await self.close_websocket()
                 except websockets.ConnectionClosed as error:
                     _LOGGER.debug(
                         "UnfoldedCircleRemote websocket closed. Waiting before reconnecting... %s",
@@ -154,6 +156,8 @@ class DockWebsocket(Websocket):
                     )
                     await asyncio.sleep(WS_RECONNECTION_DELAY)
                     continue
+                finally:
+                    await self.close_websocket()
             _LOGGER.error(
                 "UnfoldedCircleRemote exiting init_websocket, this is not normal"
             )

--- a/custom_components/unfoldedcircle/remote.py
+++ b/custom_components/unfoldedcircle/remote.py
@@ -345,6 +345,8 @@ class IR:
     async def async_learn_command(self, **kwargs: Any) -> None:
         """Learn a list of commands from a remote."""
 
+        await self.dock_coordinator.init_websocket()
+
         await self.dock_coordinator.api.get_remotes_complete()
 
         name = self.data.get("remote").get("name")
@@ -364,6 +366,8 @@ class IR:
             except Exception as err:
                 _LOGGER.error("Failed to learn '%s': %s", command, err)
                 continue
+
+        await self.dock_coordinator.close_websocket()
 
     async def _async_learn_ir_command(self, command, device, name, description, icon):
         """Learn an infrared command."""


### PR DESCRIPTION
This change does not establish a websocket connection to the dock until it is needed for IR learning or when validating the password. At present, the dock does not receive any websocket messages of config changes so the always on websocket connection is dubious. 