### PR TITLE
Allow non owners to generate long lived tokens

### DIFF
--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
 from .helpers import (
     IntegrationNotFound,
     UnableToExtractMacAddress,
+    UnableToDetermineUser,
     InvalidWebsocketAddress,
     connect_integration,
     device_info_from_discovery_info,
@@ -682,8 +683,13 @@ class UnfoldedCircleRemoteOptionsFlowHandler(config_entries.OptionsFlow):
                         )
                         errors["base"] = "ha_driver_failure"
                     except TokenRegistrationError as ex:
-                        _LOGGER.error("Error during token creation: %s", ex)
+                        _LOGGER.error(
+                            "Error during token registration on remote: %s", ex
+                        )
                         errors["base"] = "ha_driver_failure"
+                    except UnableToDetermineUser as ex:
+                        _LOGGER.error("Error determining Home Assistant user: %s", ex)
+                        errors["base"] = "user_determination"
                     except Exception as ex:
                         _LOGGER.error(
                             "Error during driver registration, continue config flow: %s",

--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -13,6 +13,6 @@
     "pyUnfoldedCircleRemote==0.13.3",
     "wakeonlan==3.1.0"
   ],
-  "version": "0.14.2",
+  "version": "0.14.3",
   "zeroconf": ["_uc-remote._tcp.local."]
 }

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -64,7 +64,8 @@
       "ha_driver_failure": "Unexpected error when configuring remote entities",
       "cannot_create_ha_token": "Unable to create Home Assistant Token",
       "invalid_websocket_address": "An invalid home assistant websocket address was supplied",
-      "invalid_host": "An invalid host was supplied for the remote"
+      "invalid_host": "An invalid host was supplied for the remote",
+      "user_determination": "Unable to determine Home Assistant User"
     },
     "step": {
       "init": {


### PR DESCRIPTION
Previously the token generation code was requiring the user to by an owner. This update removes that requirement and allows any admin to generate long lived access tokens to share with the remote. 