### PR TITLE
Send WOL packet earlier during service calls

### DIFF
--- a/custom_components/unfoldedcircle/manifest.json
+++ b/custom_components/unfoldedcircle/manifest.json
@@ -10,9 +10,9 @@
   "issue_tracker": "https://github.com/JackJPowell/hass-unfoldedcircle/issues",
   "requirements": [
     "websockets>=12.0,<14",
-    "pyUnfoldedCircleRemote==0.13.3",
+    "pyUnfoldedCircleRemote==0.13.4",
     "wakeonlan==3.1.0"
   ],
-  "version": "0.14.5",
+  "version": "0.14.6",
   "zeroconf": ["_uc-remote._tcp.local."]
 }

--- a/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
+++ b/custom_components/unfoldedcircle/pyUnfoldedCircleRemote/remote.py
@@ -1624,6 +1624,11 @@ class Remote:
     async def get_remotes(self) -> list:
         """Get list of remotes defined. (IR Remotes as defined by Unfolded Circle)."""
         remote_data = {}
+
+        if self._wake_if_asleep and self._wake_on_lan:
+            if not await self.wake():
+                raise RemoteIsSleeping
+
         async with (
             self.client() as session,
             session.get(self.url("remotes")) as response,
@@ -1740,6 +1745,10 @@ class Remote:
         delay_secs = kwargs.get("delay_secs", 0)
         repeat = kwargs.get("repeat", 1)
 
+        if self._wake_if_asleep and self._wake_on_lan:
+            if not await self.wake():
+                raise RemoteIsSleeping
+
         if activity:
             for act in self.activities:
                 if act.name == activity:
@@ -1759,10 +1768,6 @@ class Remote:
             )
         except HTTPError as ex:
             raise InvalidButtonCommand(ex.message) from ex
-
-        if self._wake_if_asleep and self._wake_on_lan:
-            if not await self.wake():
-                raise RemoteIsSleeping
 
         try:
             for _ in range(repeat):
@@ -1817,6 +1822,11 @@ class Remote:
         body_port = {}
         body_repeat = {}
         codeset_id = ""
+
+        if self._wake_if_asleep and self._wake_on_lan:
+            if not await self.wake():
+                raise RemoteIsSleeping
+
         if "code" in kwargs and "format" in kwargs:
             # Send an IR command (HEX/PRONTO)
             body = {"code": kwargs.get("code"), "format": kwargs.get("format")}


### PR DESCRIPTION
The send_ir_command and send_button_command services were eventually attempting to wake up the remote, but they were sleepy and did so too late. They are now sending a WOL packet to the remote earlier in their processing timeline. 