### PR TITLE
Add a VERSION to the config entry

### DIFF
--- a/custom_components/unfoldedcircle/config_flow.py
+++ b/custom_components/unfoldedcircle/config_flow.py
@@ -66,6 +66,8 @@ class UnfoldedCircleRemoteConfigFlow(ConfigFlow, domain=DOMAIN):
 
     reauth_entry: ConfigEntry | None = None
 
+    VERSION = 6
+
     def __init__(self) -> None:
         """Unfolded Circle Config Flow."""
         self.api_keyname: str | None = None


### PR DESCRIPTION
The config entry "handler", i.e., the class that implements it, needs to define a version that's checked by the HA core code against the version in the stored config entry and it won't allow newer config entry versions to be used with older integrations (handlers).  The current config_entry version is 6, so adding that definition.  Otherwise, the default of 1 is used and the integration won't set up properly.