### PR TITLE
Keep dock entities alive when setup fails, and poll docks for availability

### DIFF
--- a/custom_components/unfoldedcircle/__init__.py
+++ b/custom_components/unfoldedcircle/__init__.py
@@ -25,8 +25,6 @@ from .coordinator import (
 from .helpers import (
     get_registered_websocket_url,
     async_create_issue_dock_password,
-    async_create_issue_dock_unreachable,
-    async_delete_issue_dock_unreachable,
     async_create_issue_websocket_connection,
 )
 
@@ -171,22 +169,17 @@ async def async_setup_entry(
             dock_coordinator = UnfoldedCircleDockCoordinator(
                 hass, dock, entry, subentry
             )
-            try:
-                await dock_coordinator.api.update()
-                await dock_coordinator.async_config_entry_first_refresh()
-                docks[subentry_id] = dock_coordinator
-                # Clear any previous unreachable issue for this dock
-                async_delete_issue_dock_unreachable(hass, dock.id)
-            except Exception as ex:
-                _LOGGER.warning(
-                    "Could not initialize connection to dock %s (%s): %s. "
-                    "The main remote will continue to work, but dock features will be unavailable.",
-                    dock.name,
-                    dock.endpoint,
-                    ex,
-                )
-                # Create a repair issue for the unreachable dock
-                async_create_issue_dock_unreachable(hass, dock, entry, subentry, ex)
+            # Register the coordinator even when the dock does not answer.
+            # async_refresh() records a failure on the coordinator rather than
+            # raising, so the dock's entities are always created: they report
+            # unavailable while the dock is silent and recover on a later poll.
+            # async_config_entry_first_refresh() would raise instead. That left
+            # the entities uncreated, lingering as restored registry entries
+            # while the config entry still reported itself as loaded, until
+            # someone reloaded the integration by hand. The coordinator raises
+            # and clears the repair issue as reachability changes.
+            await dock_coordinator.async_refresh()
+            docks[subentry_id] = dock_coordinator
         else:
             dock = remote_api.get_dock_by_id(subentry.data["id"])
             if dock:

--- a/custom_components/unfoldedcircle/const.py
+++ b/custom_components/unfoldedcircle/const.py
@@ -9,6 +9,11 @@ CONF_ACTIVITIES_AS_SWITCHES = "activities_as_switches"
 CONF_GLOBAL_MEDIA_ENTITY = "global_media_entity"
 CONF_SUPPRESS_ACTIVITIY_GROUPS = "suppress_activity_groups"
 DEVICE_SCAN_INTERVAL = timedelta(seconds=30)
+# Docks are polled on their own, slower schedule: the data barely changes and
+# every request travels through the remote. Two consecutive misses are required
+# before a dock counts as unreachable, so one slow response stays invisible.
+DOCK_SCAN_INTERVAL = timedelta(minutes=2)
+DOCK_FAILURE_THRESHOLD = 2
 REMOTE_ON_BEHAVIOR = "remote_on_behavior"
 UC_HA_TOKEN_ID = "ws-ha-api"
 UC_HA_SYSTEM = "hass"

--- a/custom_components/unfoldedcircle/coordinator.py
+++ b/custom_components/unfoldedcircle/coordinator.py
@@ -19,9 +19,18 @@ from homeassistant.helpers.update_coordinator import (
 )
 from pyUnfoldedCircleRemote.remote import Remote
 from pyUnfoldedCircleRemote.remote_websocket import RemoteWebsocket
-from pyUnfoldedCircleRemote.dock import Dock
+from pyUnfoldedCircleRemote.dock import Dock, HTTPError as DockHTTPError
 
-from .const import DEVICE_SCAN_INTERVAL, DOMAIN
+from .const import (
+    DEVICE_SCAN_INTERVAL,
+    DOCK_FAILURE_THRESHOLD,
+    DOCK_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .helpers import (
+    async_create_issue_dock_unreachable,
+    async_delete_issue_dock_unreachable,
+)
 from .websocket import UCWebsocketClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -177,7 +186,81 @@ class UnfoldedCircleDockCoordinator(
         """Initialize the Coordinator."""
         super().__init__(hass, dock, config_entry=entry)
         self.subentry = subentry
+        # Unlike the remote, a dock has no websocket feeding this coordinator
+        # (init_websocket below is a no-op). Without polling, the dock is only
+        # ever contacted once, during setup: a dock that goes offline afterwards
+        # stays invisible because its entities keep serving their last known
+        # values. Polling on a slower schedule than the remote makes the dock's
+        # reachability observable without adding much traffic.
+        self.update_interval = DOCK_SCAN_INTERVAL
+        self._consecutive_failures = 0
+        # Guards against re-reporting an outage on every poll: creating the
+        # repair issue also logs a warning.
+        self._unreachable_reported = False
 
     async def init_websocket(self, initial_events: str = ""):
         """Initialize the Web Socket"""
         pass
+
+    async def update_data(self) -> dict[str, Any]:
+        """Poll the dock, keeping its repair issue in sync with reachability."""
+        try:
+            # The full update() is used rather than only get_info(): it also
+            # refreshes the update status that UpdateDock seeds its versions
+            # from. Without it, latest_version stays empty and the entity
+            # reports a firmware update that does not exist.
+            await self.api.update()
+        except DockHTTPError as ex:
+            # The remote answered but reported that it cannot reach the dock
+            # ("503 Connection to dock not established"), so the dock really is
+            # the faulty part here and it is worth raising a repair issue for.
+            return self._async_handle_failed_poll(ex, dock_at_fault=True)
+        except Exception as ex:
+            # The remote itself did not answer. Dock requests travel through the
+            # remote, and the remote sleeps a few minutes after it stops
+            # charging, so this also happens during entirely normal use. The
+            # dock entities still become unavailable, since they really cannot
+            # be reached, but a "dock unreachable" repair would blame the wrong
+            # device for something that resolves itself once the remote wakes.
+            return self._async_handle_failed_poll(ex, dock_at_fault=False)
+
+        self._consecutive_failures = 0
+        # Deleting an unknown issue is a documented no-op, so this also clears an
+        # issue raised before a reload, when this instance never saw the failure.
+        self._unreachable_reported = False
+        async_delete_issue_dock_unreachable(self.hass, self.api.id)
+        return vars(self.api)
+
+    def _async_handle_failed_poll(
+        self, ex: Exception, dock_at_fault: bool
+    ) -> dict[str, Any]:
+        """Account for a failed poll, tolerating a single miss.
+
+        Returns the previous data while the failure is still within the
+        tolerance, and raises UpdateFailed once it is not.
+        """
+        self._consecutive_failures += 1
+        # A single miss is usually a slow answer rather than a real outage: the
+        # library allows five seconds per call. Keep serving the previous data
+        # until two polls in a row fail, so one slow response does not flip
+        # every entity to unavailable and raise a repair issue that clears
+        # moments later.
+        if (
+            self._consecutive_failures < DOCK_FAILURE_THRESHOLD
+            and self.data is not None
+        ):
+            _LOGGER.debug(
+                "Dock %s did not answer, waiting for the next poll: %s",
+                self.api.name,
+                ex,
+            )
+            return self.data
+
+        if dock_at_fault and not self._unreachable_reported:
+            self._unreachable_reported = True
+            async_create_issue_dock_unreachable(
+                self.hass, self.api, self.config_entry, self.subentry, ex
+            )
+        raise UpdateFailed(
+            f"Error communicating with Unfolded Circle dock {self.api.name}: {ex}"
+        ) from ex

--- a/custom_components/unfoldedcircle/number.py
+++ b/custom_components/unfoldedcircle/number.py
@@ -233,7 +233,12 @@ class UCDockNumber(UnfoldedCircleDockEntity, NumberEntity):
         self.entity_description = description
         self._attr_unique_id = f"{subentry.unique_id}_{self.coordinator.api.model_number}_{self.coordinator.api.serial_number}_{description.unique_id}"
         key = "_" + description.key
-        self._attr_native_value = coordinator.data.get(key)
+        # coordinator.data is None until a refresh succeeds, which is the case
+        # when the dock did not answer during setup. Fall back to no value
+        # instead of failing the whole platform; the entity reports unavailable
+        # anyway while the coordinator is in a failed state, and picks up a real
+        # value on the first successful poll.
+        self._attr_native_value = (coordinator.data or {}).get(key)
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""

--- a/custom_components/unfoldedcircle/services.py
+++ b/custom_components/unfoldedcircle/services.py
@@ -243,12 +243,18 @@ async def async_service_handle(
                                     dock_name = coor.api.name
                                     break
 
-        # If still no dock name, fall back to single-dock auto-select
+        # If still no dock name, fall back to single-dock auto-select.
+        # Only consider docks that are currently answering: unreachable docks
+        # are registered as well, so counting all of them would drop the
+        # auto-select for a working dock as soon as a second dock is offline.
         if dock_name is None:
-            if len(config_entry.runtime_data.docks.items()) == 1:
-                dock_name = next(
-                    iter(config_entry.runtime_data.docks.values())
-                ).api.name
+            reachable_docks = [
+                coor
+                for coor in config_entry.runtime_data.docks.values()
+                if coor.last_update_success
+            ]
+            if len(reachable_docks) == 1:
+                dock_name = reachable_docks[0].api.name
             elif service_call.service in (
                 LEARN_IR_COMMAND_SERVICE,
                 SEND_IR_COMMAND_SERVICE,

--- a/custom_components/unfoldedcircle/translations/en.json
+++ b/custom_components/unfoldedcircle/translations/en.json
@@ -265,7 +265,7 @@
     },
     "dock_unreachable": {
       "title": "Dock {name} is unreachable",
-      "description": "The dock could not be reached during initialization. Error: {error}. The main remote will continue to work normally, but dock-specific features will be unavailable until the dock is back online. Try reloading the integration once the dock is accessible."
+      "description": "The dock did not respond. Error: {error}. The main remote will continue to work normally, but dock-specific features are unavailable while the dock is offline. This notice clears by itself once the dock responds again."
     }
   }
 }


### PR DESCRIPTION
Fixes #149.

## What happens today

When the dock does not answer while the integration is setting up, the call
raises and the rest of the try block never runs, so
`docks[subentry_id] = dock_coordinator` is skipped. Every dock platform iterates
`config_entry.runtime_data.docks`, so none of them create entities. The registry
entries from the previous run remain, and Home Assistant restores them as
unavailable placeholders.

The config entry still reports `state: loaded` and `reason: null`, so Home
Assistant sees nothing wrong and never retries. Only a manual reload brings the
dock back, which is the behavior I reported in #149.

The dock coordinator has a second problem. `init_websocket()` is a no-op and
`polling_data` is never set, so `update_data()` returns `vars(self.api)` without
any I/O. The only call that actually reaches the dock is the explicit
`await dock_coordinator.api.update()` in `async_setup_entry`, and it runs once.
`last_update_success` therefore stays true forever, and a dock that dies while
Home Assistant is running keeps serving its last known values with no sign that
anything is wrong.

## What this changes

`async_refresh()` replaces `async_config_entry_first_refresh()`, and the
coordinator is registered either way, so the dock entities always exist. They
report unavailable while the dock is silent and recover on a later poll.

`UnfoldedCircleDockCoordinator` now overrides `update_data()` and calls
`api.update()` there, so a poll actually reaches the dock. The coordinator runs
on its own interval, separate from the remote. `DOCK_SCAN_INTERVAL` is 2 minutes
and `DOCK_FAILURE_THRESHOLD` is 2. That interval is deliberately slower than
`DEVICE_SCAN_INTERVAL`, which is 30 seconds, since dock data barely changes and
every request travels through the remote.

A single failed poll is tolerated. The library allows five seconds per call in
`dock.py`, and one slow answer should not flip every entity to unavailable and
raise a repair that clears again moments later.

The repair issue moved into the coordinator, which tracks reachability over
time. It appears only when the remote answers the dock request with an HTTP
error, such as `503 Connection to dock not established`. If the remote itself
does not answer, the entities still go unavailable, but no repair is raised: the
remote sleeps a few minutes after it stops charging, and dock requests travel
through it, so a repair pointed at the dock would fire during normal use.

Three smaller changes come with it:

- `number.py` read `coordinator.data.get(key)` in `UCDockNumber.__init__`.
  `coordinator.data` is `None` until a refresh succeeds, so registering a
  coordinator whose first refresh failed would break setup of the whole number
  platform with an `AttributeError`. The read now falls back to `None`.
- `services.py` auto-selected the dock when exactly one was registered.
  Unreachable docks are registered now, so that count would include them, and
  someone with one working dock and one dead dock would lose auto-select. It now
  counts only the docks that are answering.
- The `dock_unreachable` text said the dock could not be reached "during
  initialization" and suggested reloading. Neither is true anymore.

## Testing

Tested against Home Assistant 2026.7.4 with a Remote Two and a Dock Two, over
several restarts:

| Scenario | Result |
| --- | --- |
| Normal start | dock entities available, no repair |
| Dock loses power while running | unavailable after two failed polls, repair raised, one warning logged |
| Restart with the dock powered off | entities created and unavailable, no restored placeholders, no platform error |
| Dock powered back on | available again within one poll, repair cleared, no reload |
| Remote asleep, dock powered | entities unavailable, no repair raised |
| Timeout on the first dock call | entities created and unavailable, no repair, recovered by a later poll |
| Single slow response | tolerated, nothing user-visible |

The last case is the one from #149. That timing cannot be triggered on demand,
so I raised `TimeoutError` once on the first refresh to reach it. Everything
after that point is real: the later polls make actual calls, and the entities
came back on their own without a reload or a restart. The same run also caught
the dock being genuinely unreachable for a few minutes, which took the other
branch and raised a repair that cleared itself once the dock answered again.

## Notes

The `HTTPError` imported at the top of `coordinator.py` comes from
`urllib.error`, while the library raises its own `HTTPError` from
`pyUnfoldedCircleRemote.dock`.
The pre-existing `except HTTPError` branch in the base coordinator therefore
never matches. That branch predates this change, so I left it alone. The new
dock branch catches the library's class explicitly, so it does fire. A 401 from
a revoked API key arrives as that same library `HTTPError`, so a revoked key
shows up as a dock repair rather than an auth problem. The old
code caught it under `except Exception` and did the same, so this patch does not
change that. Filtering on the status code would separate the two, if you
want that in this patch.
